### PR TITLE
Improve Pedantix lemma handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PlantQuizz est un quiz web centré sur les sciences du végétal. Il propose tro
 - **Pédantix végétal** – variante façon « texte masqué » : tapez des mots pour dévoiler le contenu et devinez le titre.
 
 
-Le site est accessible en ligne sur [https://edezi.github.io/plantquizz/](https://edezi.github.io/plantquiz/) et peut également être ouvert localement en lançant `index.html` dans un navigateur moderne.
+Le site est accessible en ligne sur [https://edezi.github.io/plantquiz/](https://edezi.github.io/plantquiz/) (le dépôt GitHub correspondant est désormais `EdeZi/plantquiz`) et peut également être ouvert localement en lançant `index.html` dans un navigateur moderne.
 
 ## Fonctionnement du système Elo
 

--- a/index.html
+++ b/index.html
@@ -682,10 +682,13 @@ $("profReset").onclick=()=>{ resetProfFields(); profOutput.value=""; };
 
 /* ========= PÉDANTIX (daily) — lemmatisation FR renforcée ========= */
 const wordRe = /[A-Za-zÀ-ÖØ-öø-ÿ'-]+|[^A-Za-zÀ-ÖØ-öø-ÿ'-]+/g;
-let pedState = { date:null, target:null, text:"", tokens:[], revealed:new Set(), guessed:[] };
+let pedState = { date:null, target:null, text:"", tokens:[], revealed:new Set(), guessed:[], targetKeys:new Set() };
 
 /* irréguliers + participes présents fréquents (sans accents car strip) */
 const IRREG_FORMS = {
+  "etre":"etre",
+  "faire":"faire",
+  "dire":"dire",
   /* AVOIR */
   "ai":"avoir","as":"avoir","a":"avoir","avons":"avoir","avez":"avoir","ont":"avoir",
   "avais":"avoir","avait":"avoir","avions":"avoir","aviez":"avoir","avaient":"avoir",
@@ -808,9 +811,11 @@ const IRREG_FORMS = {
 
 function lemmaFr(rawWord){
   // retire élisions communes et normalise
-  let w = strip(rawWord.replace(/^([ldmtscnj])'|^qu'|^jusqu'|^lorsqu'|^puisqu'/i, ""));
+  const cleaned = (rawWord || "").replace(/^([ldmtscnj])'|^qu'|^jusqu'|^lorsqu'|^puisqu'/i, "");
+  let w = strip(cleaned);
   if (!w) return w;
   if (IRREG_FORMS[w]) return IRREG_FORMS[w];
+  if(/\s/.test(cleaned)) return w;
 
   // RÈGLES PRIORITAIRES — participes/adjectifs
   // 1er groupe: montant/montante/montants/montantes -> monter
@@ -824,36 +829,89 @@ function lemmaFr(rawWord){
     if (stem.length>=3) return stem;
   }
 
+  const rawLower = cleaned.toLowerCase();
+  const rawNFD = cleaned.normalize("NFD");
+  const hasAcute = /\u0301/.test(rawNFD) || rawLower.includes("é");
+
   // Heuristiques verbales — ordre important
   const rules = [
-    // participes/gérondifs 1er groupe
-    [/(ees|ee|es|e)$/i, "er"],
-    [/ant$/i, "er"],
+    // participes/gérondifs 1er groupe (uniquement si accent dans la forme originale)
+    [/(ees|ee|es|e)$/i, v => hasAcute ? v.replace(/(ees|ee|es|e)$/i, "er") : v],
+    [/ant$/i, v => v.replace(/ant$/i, "er")],
     // participes/gérondifs 2e groupe
-    [/(ies|ie|is|it)$/i, "ir"],
-    [/(ues|ue|us|u)$/i, ""],
+    [/(ies|ie|is|it)$/i, v => /(ais|ait)$/i.test(v) ? v : v.replace(/(ies|ie|is|it)$/i, "ir")],
+    [/(ues)$/i, v => v.replace(/ues$/i, "u")],
+    [/(ue)$/i, v => v.replace(/ue$/i, "u")],
+    [/(us)$/i, v => v.replace(/us$/i, "u")],
+    [/(u)$/i, v => v],
     // imparfait
-    [/(ais|ait|ions|iez|aient)$/i, ""],
+    [/(ais|ait|ions|iez|aient)$/i, v => v.replace(/(ais|ait|ions|iez|aient)$/i, "")],
     // futur/conditionnel 1er groupe
-    [/(erai|eras|era|erons|erez|eront)$/i, "er"],
-    [/(erais|erait|erions|eriez|eraient)$/i, "er"],
+    [/(erai|eras|era|erons|erez|eront)$/i, v => v.replace(/(erai|eras|era|erons|erez|eront)$/i, "er")],
+    [/(erais|erait|erions|eriez|eraient)$/i, v => v.replace(/(erais|erait|erions|eriez|eraient)$/i, "er")],
     // présent 1er groupe
-    [/(e|es|ons|ez|ent)$/i, "er"],
+    [/(e|es|ons|ez|ent)$/i, v => /(euses?|trices?|ives?|elles?|ennes?|onnes?|ettes?)$/i.test(v) ? v : v.replace(/(e|es|ons|ez|ent)$/i, "er")],
     // 2e groupe -ir
-    [/(irai|iras|ira|irons|irez|iront)$/i, "ir"],
-    [/(irais|irait|irions|iriez|iraient)$/i, "ir"],
-    [/(issons|issez|issent)$/i, "ir"],
-    [/(is|it)$/i, "ir"],
+    [/(irai|iras|ira|irons|irez|iront)$/i, v => v.replace(/(irai|iras|ira|irons|irez|iront)$/i, "ir")],
+    [/(irais|irait|irions|iriez|iraient)$/i, v => v.replace(/(irais|irait|irions|iriez|iraient)$/i, "ir")],
+    [/(issons|issez|issent)$/i, v => v.replace(/(issons|issez|issent)$/i, "ir")],
+    [/(is|it)$/i, v => v.replace(/(is|it)$/i, "ir")],
     // 3e groupe divers
-    [/re$/i, "re"]
+    [/re$/i, v => v]
   ];
-  for(const [re, rep] of rules){
-    if(re.test(w)){
-      const stem = w.replace(re, rep);
-      if(stem.length>=3) return stem;
+  let lemma = w;
+  for(const [re, transform] of rules){
+    if(re.test(lemma)){
+      const stem = transform(lemma);
+      if(stem && stem.length>=3 && stem!==lemma){
+        lemma = IRREG_FORMS[stem] || stem;
+      }
     }
   }
-  return w;
+  return lemma;
+}
+
+function expandGenderNumber(base, acc){
+  if(!base || base.length<3) return;
+  if(/\s/.test(base)) return;
+  const rules = [
+    [/euses?$/i, val => val.replace(/euses?$/i, "eux")],
+    [/trices?$/i, val => val.replace(/trices?$/i, "teur")],
+    [/rices?$/i, val => val.replace(/rices?$/i, "eur")],
+    [/ives?$/i, val => val.replace(/ives?$/i, "if")],
+    [/ales?$/i, val => val.replace(/ales?$/i, "al")],
+    [/elles?$/i, val => val.replace(/elles?$/i, "el")],
+    [/ennes?$/i, val => val.replace(/ennes?$/i, "en")],
+    [/onnes?$/i, val => val.replace(/onnes?$/i, "on")],
+    [/eaux$/i, val => val.replace(/eaux$/i, "eau")],
+    [/aux$/i, val => val.replace(/aux$/i, "al")],
+    [/ettes?$/i, val => val.replace(/ettes?$/i, "et")]
+  ];
+  for(const [re, fn] of rules){
+    if(re.test(base)){
+      const v = fn(base);
+      if(v && v.length>=3) acc.add(v);
+    }
+  }
+  if(base.endsWith("es") && base.length>4) acc.add(base.slice(0,-2));
+  if(base.endsWith("s") && base.length>3) acc.add(base.slice(0,-1));
+  if(base.endsWith("x") && base.length>3) acc.add(base.slice(0,-1));
+}
+
+function buildKeySet(norm, lemma, raw){
+  const set = new Set();
+  const add = v => { if(v && v.length) set.add(v); };
+  add(norm);
+  add(lemma);
+  if(raw && raw!==norm){ add(strip(raw)); }
+  [norm, lemma].forEach(b=>expandGenderNumber(b, set));
+  return set;
+}
+
+function hasIntersection(setA, setB){
+  if(!setA || !setB) return false;
+  for(const v of setA){ if(setB.has(v)) return true; }
+  return false;
 }
 
 function tokenize(text){
@@ -862,7 +920,8 @@ function tokenize(text){
     const isWord = /[A-Za-zÀ-ÖØ-öø-ÿ'-]+/.test(p);
     const norm = isWord ? strip(p) : p;
     const lemma = isWord ? lemmaFr(p) : p;
-    return { raw:p, norm, lemma, isWord };
+    const keys = isWord ? buildKeySet(norm, lemma, p) : new Set();
+    return { raw:p, norm, lemma, isWord, keys };
   });
 }
 function titleMask(){
@@ -883,7 +942,7 @@ function renderPed(){
     span.className = "token";
     if(!t.isWord){ span.textContent = t.raw; }
     else {
-      const show = pedState.revealed.has(t.norm) || pedState.revealed.has(t.lemma) || (t.norm===strip(pedState.target)) || (t.lemma===lemmaFr(pedState.target));
+      const show = hasIntersection(t.keys, pedState.revealed) || hasIntersection(t.keys, pedState.targetKeys);
       span.innerHTML = show ? t.raw : `<span class="mask">${"█".repeat(Math.max(1, t.raw.length))}</span>`;
     }
     frag.appendChild(span);
@@ -897,6 +956,7 @@ function pickDaily(){
   pedState.text = (entry && entry.text) || "Texte démo.";
   pedState.tokens = tokenize(pedState.text);
   pedState.revealed = new Set(); // tout masqué
+  pedState.targetKeys = buildKeySet(strip(pedState.target), lemmaFr(pedState.target), pedState.target);
   pedState.guessed = [];
   $("pedGuesses").innerHTML=""; $("pedScore").hidden=true;
   renderPed();
@@ -905,21 +965,19 @@ function guessWord(w){
   const gRaw = (w||"").trim(); if(!gRaw) return {hits:0,win:false};
   const gNorm = strip(gRaw);
   const gLemma = lemmaFr(gRaw);
-  const win = gNorm === strip(pedState.target) || gLemma === lemmaFr(pedState.target);
+  const guessKeys = buildKeySet(gNorm, gLemma, gRaw);
+  const win = hasIntersection(guessKeys, pedState.targetKeys);
   let hits = 0;
   if(!win){
-    let found=false;
     for(const t of pedState.tokens){
       if(!t.isWord) continue;
-      if(t.norm===gNorm || t.lemma===gLemma){
-        pedState.revealed.add(t.norm);
-        pedState.revealed.add(t.lemma);
-        found=true;
+      if(hasIntersection(t.keys, guessKeys)){
+        hits++;
+        t.keys.forEach(k=>pedState.revealed.add(k));
       }
     }
-    if(found){
-      hits = pedState.tokens.filter(t => t.isWord && (t.norm===gNorm || t.lemma===gLemma)).length;
-    }
+  } else {
+    pedState.tokens.forEach(t=>{ if(t.isWord) t.keys.forEach(k=>pedState.revealed.add(k)); });
   }
   renderPed();
   return {hits,win};
@@ -928,15 +986,12 @@ function pedHint(){
   const cand=[];
   for(const t of pedState.tokens){
     if(!t.isWord) continue;
-    if(t.norm===strip(pedState.target) || t.lemma===lemmaFr(pedState.target)) continue;
-    if(!pedState.revealed.has(t.norm) && !pedState.revealed.has(t.lemma)){ // bugfix: revealed
-      cand.push(t);
-    }
+    if(hasIntersection(t.keys, pedState.targetKeys)) continue;
+    if(!hasIntersection(t.keys, pedState.revealed)) cand.push(t);
   }
   if(!cand.length) return;
   const t = cand[Math.floor(Math.random()*cand.length)];
-  pedState.revealed.add(t.norm);
-  pedState.revealed.add(t.lemma);
+  t.keys.forEach(k=>pedState.revealed.add(k));
   renderPed();
 }
 $("pedInput").addEventListener("keydown",e=>{


### PR DESCRIPTION
## Summary
- refine the French lemmatisation helper to protect irregular bases and avoid over-aggressive verb heuristics
- introduce morphological key sets so conjugated and gender/number variants reveal Pedantix tokens consistently
- update Pedantix rendering, hinting, and win logic to rely on the expanded key sets and track target variants

## Testing
- node - <<'NODE' … (sanity-check lemmatisation outputs)

------
https://chatgpt.com/codex/tasks/task_e_68e375e1fa04832e89c46bbaab89bc84