### PR TITLE
Allow Pedantix titles to reveal word-by-word

### DIFF
--- a/data/pedantix_daily.json
+++ b/data/pedantix_daily.json
@@ -1,1002 +1,1002 @@
 [
   {
-    "date": "2024-07-01",
-    "target": "Xylème",
-    "text": "Le xylème assure la montée de la sève brute depuis les racines vers les organes aériens, répondant en permanence aux variations de transpiration imposées par la météo et l'activité des feuilles. Lorsque la demande est forte, la tension exercée sur cette colonne d'eau mobilise l'élasticité des parois lignifiées et révèle les limites de la conductivité hydraulique.\n\nAu microscope, on observe une succession de vaisseaux et de trachéides au lumen élargi, consolidés par des épaississements annulaires ou spiralés qui protègent le flux contre les collapsus. Les ponctuations bordées permettent des dérivations de secours, mais restent des points de fragilité lors des épisodes d'embolie.\n\nDans les systèmes agricoles, préserver un sol structuré et limiter le tassement permet au xylème de maintenir une alimentation régulière des feuilles. Les itinéraires techniques qui favorisent un enracinement profond et une irrigation raisonnée réduisent les ruptures de colonne d'eau et sécurisent la production."
-  },
-  {
-    "date": "2024-07-02",
-    "target": "Phloème",
-    "text": "Le phloème distribue les assimilats produits par la photosynthèse vers les organes demandeurs, qu'il s'agisse de jeunes feuilles, de racines ou de réserves. Sa plasticité permet de réorienter les flux selon les besoins, par exemple vers une inflorescence en croissance rapide ou un tubercule en remplissage.\n\nSur une coupe colorée, les tubes criblés et leurs cellules compagnes révèlent un contenu visqueux riche en sucres et en hormones de signalisation. Les plaques criblées se renouvellent régulièrement et les calloses formées en réponse au stress servent de vannes pour isoler une portion du réseau.\n\nPour l'agronome, tout facteur qui freine la photosynthèse ou endommage le phloème se traduit immédiatement par une perte de rendement. Les stratégies de lutte contre les insectes piqueurs-suceurs, la gestion du stress hydrique et le choix variétal influencent donc directement l'efficacité de cette voie de transport."
-  },
-  {
-    "date": "2024-07-03",
-    "target": "Cambium",
-    "text": "Le cambium constitue une fine assise méristématique responsable de la croissance en diamètre des tiges et des racines. Il réactive chaque saison ses divisions pour former de nouveaux anneaux conducteurs, modulant le rapport entre xylème et phloème selon les besoins de la plante.\n\nEn coupe transversale, on distingue ses cellules fusiformes à paroi fine capables de se dédifférencier et de redonner des tissus spécialisés. Les gradients hormonaux latéraux guident l'orientation des divisions et favorisent une alternance régulière des files conductrices.\n\nEn arboriculture, la maîtrise des tailles, des greffes et de la nutrition dépend de la vitalité du cambium. Des stress mécaniques ou hydriques mal gérés peuvent interrompre ses activités et compromettre la cicatrisation des plaies ou la reprise des greffons."
-  },
-  {
-    "date": "2024-07-04",
-    "target": "Méristème apical",
-    "text": "Le méristème apical des tiges pilote l'allongement et l'organisation des organes aériens, depuis les feuilles jusqu'aux fleurs. Sa zone centrale conserve des cellules indifférenciées, tandis que ses zones périphériques fournissent rapidement des cellules spécialisées.\n\nAu microscope, la distinction entre tunica et corpus révèle des divisions orientées qui déterminent la phyllotaxie et l'architecture de la plante. Les signaux hormonaux comme les auxines concentrées au sommet orchestrent ces dynamiques et assurent la dominance apicale.\n\nEn production légumière ou fruitière, la gestion des pincements, de l'ébourgeonnage ou de l'ébourgeonnement vise à moduler l'activité du méristème apical. Comprendre son fonctionnement aide à équilibrer végétation et fructification selon les objectifs de rendement."
-  },
-  {
-    "date": "2024-07-05",
-    "target": "Méristème racinaire",
-    "text": "Le méristème racinaire assure la croissance continue des racines pour explorer de nouveaux volumes de sol. Sa coiffe protectrice amortit les chocs mécaniques et sécrète des mucilages qui facilitent la progression à travers les agrégats.\n\nLes cellules initiales s'organisent en colonnes donnant chacune un tissu : épiderme, cortex ou cylindre central. La présence d'un centre quiescent limite l'accumulation de mutations et sert de réserve pour régénérer le méristème après un stress.\n\nEn agronomie, soutenir l'activité du méristème racinaire passe par une bonne structure de sol, des apports organiques adaptés et la maîtrise de l'hydratation. Ces facteurs conditionnent l'exploration racinaire et donc l'absorption d'eau et de nutriments."
-  },
-  {
-    "date": "2024-07-06",
-    "target": "Parenchyme palissadique",
-    "text": "Le parenchyme palissadique constitue la principale zone photosynthétique des feuilles, grâce à ses cellules allongées riches en chloroplastes. Son organisation compacte maximise la capture de lumière avant que les photons ne se dispersent dans les tissus plus lâches.\n\nLes chloroplastes s'y réarrangent selon l'intensité lumineuse, se plaçant sur les parois latérales en cas de forte lumière pour éviter la photoinhibition. Les mouvements cytoplasmiques assurent une distribution homogène des ressources produites vers les autres tissus.\n\nChez les espèces cultivées, l'épaisseur du parenchyme palissadique varie selon les conditions de culture et le niveau d'ombre. Les pratiques de densité de semis ou de conduite de la canopée influencent donc la performance photosynthétique et le rendement."
-  },
-  {
-    "date": "2024-07-07",
-    "target": "Parenchyme spongieux",
-    "text": "Le parenchyme spongieux forme un réseau lacunaire facilitant les échanges gazeux entre les cellules chlorophylliennes et les stomates. Ses espaces intercellulaires servent de réserve temporaire de CO₂ et de voie de diffusion de la vapeur d'eau.\n\nLes cellules y sont plus arrondies et disposées de façon lâche, ce qui favorise la circulation de l'air mais impose une cohésion par des faisceaux conducteurs bien ancrés. Les gradients de concentration qui s'y établissent conditionnent la vitesse de la photosynthèse.\n\nPour les cultures sous serre ou en champ, la gestion de l'humidité ambiante et de la ventilation limite les risques de condensation dans ce tissu. Une atmosphère trop saturée favorise les pathogènes foliaires et ralentit les échanges gazeux indispensables à la croissance."
-  },
-  {
-    "date": "2024-07-08",
-    "target": "Cuticule foliaire",
-    "text": "La cuticule foliaire protège les tissus internes contre la déshydratation et les agressions extérieures grâce à sa composition en cutine et cires. Elle reflète une partie du rayonnement solaire et limite l'adhésion des gouttelettes, réduisant la durée d'humectation des feuilles.\n\nObservée en microscopie électronique, elle montre des strates successives et des micro-reliefs qui influencent la mouillabilité et la diffusion de composés volatils. Son épaisseur et sa composition évoluent selon l'âge de la feuille et les conditions climatiques.\n\nPour les agriculteurs, la cuticule conditionne l'efficacité des traitements foliaires et la résistance aux sécheresses ponctuelles. Adapter le volume d'eau, le pH des bouillies et choisir des adjuvants appropriés aide à traverser cette barrière sans l'endommager."
-  },
-  {
-    "date": "2024-07-09",
-    "target": "Stomate",
-    "text": "Les stomates régulent les échanges de gaz entre la plante et l'atmosphère, ajustant l'ouverture des ostioles en fonction de la lumière, de l'humidité et de la disponibilité en CO₂. Leur réactivité permet d'équilibrer photosynthèse et transpiration.\n\nLes cellules de garde renferment des chloroplastes actifs et une paroi interne épaissie qui orchestre l'ouverture en modifiant la turgescence. Des cellules annexes et le réseau d'ions potassium, malate ou chlorures assurent les variations osmotiques rapides.\n\nEn conduite culturale, maîtriser l'irrigation, la nutrition potassique et le climat autour de la culture soutient le fonctionnement stomatique. Des stress répétés peuvent entraîner des dysfonctionnements et diminuer la capacité photosynthétique."
-  },
-  {
-    "date": "2024-07-10",
-    "target": "Lenticelle",
-    "text": "Les lenticelles offrent une voie d'échange gazeux dans les organes ligneux recouverts de liège, assurant l'oxygénation des tissus internes. Elles se forment à partir du phellogène et remplacent les stomates perdus lors de la formation du périderme.\n\nLeur structure irrégulière, parfois en forme de lentille ou de fissure, présente des tissus lâches qui laissent diffuser l'air tout en empêchant les infiltrations excessives d'eau. Des subérifications partielles limitent les risques d'invasion pathogène.\n\nEn arboriculture fruitière, l'aspect des lenticelles renseigne sur la santé du bois et la qualité de la peau des fruits. Une humidité excessive peut les ouvrir et favoriser des infections, tandis qu'un stress hydrique prolongé tend à les refermer."
-  },
-  {
-    "date": "2024-07-11",
-    "target": "Racine pivotante",
-    "text": "La racine pivotante explore en profondeur les horizons du sol, ancrant solidement la plante et accédant à des réserves d'eau éloignées de la surface. Elle domine souvent les racines latérales lors des premiers stades de développement.\n\nEn coupe, elle montre un cylindre central robuste entouré d'un cortex épais capable de stocker des réserves. Les différences de densité entre tissus témoignent de la transition progressive vers un fonctionnement plus ligneux.\n\nDans les systèmes de grandes cultures ou de luzerne, préserver un sol meuble en profondeur et éviter les semelles de labour assure l'efficacité de la racine pivotante. Cela conditionne la résilience face aux sécheresses estivales."
-  },
-  {
-    "date": "2024-07-12",
-    "target": "Racine fasciculée",
-    "text": "Les racines fasciculées forment un faisceau dense de racines de même diamètre qui explorent rapidement les premiers horizons du sol. Elles offrent une grande capacité d'absorption et stabilisent efficacement les particules superficielles.\n\nAu microscope, elles présentent de nombreux points d'émergence pour des racines secondaires, multipliant les zones d'échange et de colonisation mycorhizienne. Leur architecture confère une grande plasticité aux graminées.\n\nPour les céréales ou les oignons, la maîtrise du lit de semences et des irrigations d'implantation favorise un bon développement des racines fasciculées. Leur santé conditionne l'efficacité de l'absorption minérale et donc le rendement."
-  },
-  {
-    "date": "2024-07-13",
-    "target": "Rhizoderme",
-    "text": "Le rhizoderme constitue l'épiderme des racines jeunes, interface directe entre la plante et la solution du sol. Ses cellules fines laissent passer l'eau et les ions avant que les tissus ne se subérifient plus tardivement.\n\nIl est le siège de la formation des poils absorbants, prolongeant la surface d'échange et hébergeant fréquemment des micro-organismes bénéfiques. Les exsudats libérés par ces cellules influencent la rhizosphère.\n\nDans les contextes agricoles, un rhizoderme fonctionnel dépend d'un bon état sanitaire du sol, de l'absence de toxicité et d'une humidité suffisante. Les stress chimiques ou salins peuvent rapidement le dégrader et limiter l'absorption."
-  },
-  {
-    "date": "2024-07-14",
-    "target": "Coiffe racinaire",
-    "text": "La coiffe racinaire protège le méristème apical en amortissant les frottements contre les particules du sol. Elle oriente aussi la croissance en percevant la gravité et en modulant la distribution des auxines.\n\nSes cellules mucilagineuses se renouvellent constamment et libèrent des polysaccharides qui facilitent la pénétration. Des statolithes internes renseignent la plante sur la direction à prendre pour maintenir une croissance verticale.\n\nEn agronomie, préserver la coiffe racinaire implique d'éviter les compactages sévères et les sols saturés en eau qui pourraient l'asphyxier. Des semis trop profonds ou des sols croûtés freinent son action protectrice et la vigueur des plantules."
-  },
-  {
-    "date": "2024-07-15",
-    "target": "Poil absorbant",
-    "text": "Les poils absorbants augmentent considérablement la surface d'échange des racines fines, captant eau et nutriments dissous. Leur durée de vie courte impose un renouvellement permanent en fonction des zones explorées.\n\nChaque poil est une extension d'une cellule du rhizoderme, dépourvue de cuticule, ce qui facilite les flux d'eau mais expose aux pathogènes du sol. Leur densité dépend des gradients hormonaux et de la disponibilité en phosphore.\n\nPour les cultures exigeantes, maintenir une humidité régulière et des apports organiques modérés favorise une forte densité de poils absorbants. Les pratiques de fertilisation localisée doivent rester douces pour ne pas les brûler."
-  },
-  {
-    "date": "2024-07-16",
-    "target": "Symbiose mycorhizienne",
-    "text": "La symbiose mycorhizienne associe les racines des plantes et des champignons qui étendent la zone d'exploration du sol. Les hyphes apportent des nutriments peu mobiles, notamment le phosphore, en échange de sucres.\n\nOn distingue des mycorhizes arbusculaires et ectomycorhiziennes, chacune présentant des structures d'échange caractéristiques comme les arbuscules ou les manchons fongiques. Ces interfaces optimisent les transferts et protègent la racine des pathogènes.\n\nEn agriculture, favoriser la symbiose mycorhizienne passe par une réduction du travail du sol, des rotations diversifiées et l'utilisation raisonnée de fongicides. Des inoculums peuvent être appliqués lors du semis pour accélérer la colonisation."
-  },
-  {
-    "date": "2024-07-17",
-    "target": "Nodulation des légumineuses",
-    "text": "La nodulation des légumineuses permet la fixation symbiotique de l'azote atmosphérique, rendant les plantes partiellement autonomes vis-à-vis des apports minéraux. Chaque nodule héberge des bactéries spécifiques capables de réduire le diazote.\n\nLes nodules actifs présentent une zone rose riche en léghémoglobine, signe d'une oxygénation contrôlée indispensable à l'activité de la nitrogénase. Leur développement dépend d'un dialogue moléculaire précis entre plante et micro-organisme.\n\nPour les agriculteurs, réussir la nodulation nécessite d'ensemencer des souches adaptées, de limiter les apports d'azote minéral au semis et de maintenir un pH favorable. Une nodulation efficace réduit les coûts de fertilisation et améliore la fertilité du sol."
-  },
-  {
-    "date": "2024-07-18",
-    "target": "Rhizobium",
-    "text": "Les bactéries du genre Rhizobium initient la nodulation en pénétrant les racines des légumineuses via un filament d'infection. Elles adaptent leur métabolisme pour devenir des bactéroïdes capables de fixer l'azote.\n\nLeurs génomes portent des plasmides symbiotiques qui codent les facteurs Nod et les systèmes de fixation. La communication chimique avec la plante déclenche des courbures des poils absorbants et la formation du nodule.\n\nEn production, sélectionner des inoculums de Rhizobium compatibles avec la variété cultivée est crucial pour obtenir une fixation azotée optimale. Des analyses de nodulation en début de cycle permettent d'ajuster la stratégie de fertilisation."
-  },
-  {
-    "date": "2024-07-19",
-    "target": "Azote nitrique",
-    "text": "L'azote nitrique représente une forme très mobile dans le sol, facilement absorbée par les racines mais sujette au lessivage. Il résulte de la nitrification et alimente rapidement la synthèse des protéines végétales.\n\nAu niveau cellulaire, il est réduit en ammonium grâce à la nitrate réductase, une enzyme sensible à l'état nutritionnel et à la lumière. Son assimilation nécessite une énergie métabolique et un approvisionnement suffisant en carbone.\n\nEn fertilisation, ajuster les apports d'azote nitrique en fonction des stades critiques évite les pertes et les excès de vigueur. L'utilisation de couverts piégeant les nitrates limite les fuites hivernales et protège la qualité de l'eau."
-  },
-  {
-    "date": "2024-07-20",
-    "target": "Azote ammoniacal",
-    "text": "L'azote ammoniacal est une forme moins mobile que le nitrate, susceptible d'être adsorbée sur le complexe argilo-humique. Il peut être assimilé directement par les racines ou transformé par nitrification.\n\nSon assimilation passe par la glutamine synthétase et la glutamate synthase, enzymes clés du métabolisme azoté. Un excès d'ammonium dans la rhizosphère peut provoquer des déséquilibres ioniques et acidifier le milieu.\n\nEn pratique agricole, l'apport d'azote ammoniacal est privilégié sur sols froids ou pour des cultures capables de l'utiliser efficacement. Les inhibiteurs de nitrification prolongent sa présence et synchronisent mieux l'offre avec la demande des plantes."
-  },
-  {
-    "date": "2024-07-21",
-    "target": "Nitrification",
-    "text": "La nitrification convertit l'ammonium en nitrate grâce à deux groupes de bactéries autotrophes, Nitrosomonas et Nitrobacter. Ce processus a lieu dans les sols bien aérés et influence fortement la disponibilité en azote pour les plantes.\n\nAu niveau biochimique, il libère des protons qui acidifient localement la rhizosphère, modifiant l'équilibre des cations. La température, l'humidité et l'aération déterminent la vitesse de ces réactions successives.\n\nPour la gestion agronomique, ralentir la nitrification permet de synchroniser l'offre d'azote avec la demande de la culture et de limiter les pertes par lessivage. Des inhibiteurs spécifiques ou des apports fractionnés constituent des leviers efficaces."
-  },
-  {
-    "date": "2024-07-22",
-    "target": "Dénitrification",
-    "text": "La dénitrification réduit les nitrates en gaz nitreux ou en azote moléculaire dans les zones mal aérées du sol. Elle implique des bactéries hétérotrophes qui utilisent les nitrates comme accepteurs d'électrons en absence d'oxygène.\n\nCe processus dépend de la disponibilité en matière organique facilement dégradable et de la température. Il peut représenter une perte d'azote importante, mais contribue aussi à l'épuration des eaux excédentaires.\n\nDans les parcelles, limiter les périodes de saturation en eau et éviter les excès de fertilisation réduit les risques de dénitrification incontrôlée. Les drains, les bandes enherbées et les couverts végétaux jouent un rôle de tampon."
-  },
-  {
-    "date": "2024-07-23",
-    "target": "Matière organique stable",
-    "text": "La matière organique stable constitue la fraction humifiée persistante du sol, agissant comme réserve de nutriments et régulateur de structure. Elle se forme lentement à partir des résidus végétaux et animaux transformés par la vie du sol.\n\nSes composés aromatiques et colloïdaux possèdent une forte capacité d'échange cationique, améliorant la rétention d'éléments fertilisants. Ils contribuent également à la couleur sombre et à la capacité tampon du sol.\n\nEn agriculture durable, maintenir ou accroître la matière organique stable passe par l'apport régulier de résidus, de composts mûrs et la réduction du travail intensif. Elle favorise la résilience face à la sécheresse et à l'érosion."
-  },
-  {
-    "date": "2024-07-24",
-    "target": "Complexe argilo-humique",
-    "text": "Le complexe argilo-humique résulte de l'association entre particules d'argile et matière organique, formant des agrégats stables riches en charges négatives. Il joue un rôle central dans la fertilité chimique en retenant les cations nutritifs.\n\nCette structure colloïdale protège les argiles de la dispersion et sert de support à la vie microbienne. Elle influence la floculation et la stabilité des agrégats face aux pluies battantes.\n\nLes pratiques qui préservent le complexe argilo-humique incluent l'apport d'amendements organiques, la limitation du travail intensif et la couverture permanente du sol. Elles maintiennent une fertilité durable et limitent les lessivages."
-  },
-  {
-    "date": "2024-07-25",
-    "target": "Horizon A du sol",
-    "text": "L'horizon A correspond à la couche de surface riche en matière organique et en activité biologique. C'est la zone principale d'enracinement des cultures et des échanges gazeux.\n\nSa structure grumeleuse et sa couleur sombre reflètent l'accumulation de résidus décomposés et de microfaune. Les agrégats y sont souvent plus stables grâce à l'activité des racines et des vers de terre.\n\nPour les agriculteurs, protéger l'horizon A revient à limiter l'érosion, éviter la compaction et maintenir une couverture végétale. Cette couche conditionne la fertilité et la capacité d'infiltration de la parcelle."
-  },
-  {
-    "date": "2024-07-26",
-    "target": "Horizon B du sol",
-    "text": "L'horizon B se caractérise par une accumulation de matériaux lessivés depuis la surface, comme les argiles, les oxydes de fer ou la matière organique. Sa couleur plus rouge ou plus dense témoigne de ces migrations.\n\nSa structure peut devenir plus massive ou prismatique, limitant parfois la circulation de l'eau et des racines. Les transitions entre horizon A et B dépendent du climat et de la nature du matériau parental.\n\nDans la gestion culturale, connaître la profondeur et la compacité de l'horizon B permet d'ajuster le travail du sol et le drainage. Des fissurations profondes ou des sous-soleuses ponctuelles peuvent améliorer son accessibilité."
-  },
-  {
-    "date": "2024-07-27",
-    "target": "Horizon C du sol",
-    "text": "L'horizon C correspond au matériau parental faiblement altéré, souvent constitué de fragments rocheux ou de dépôts meubles. Il marque la transition vers la roche mère.\n\nLes processus biologiques y sont plus limités, mais des racines profondes peuvent exploiter ses fissures pour accéder à l'eau. La nature de cet horizon conditionne la vitesse de régénération des horizons supérieurs.\n\nPour les cultures pérennes, la connaissance de l'horizon C guide le choix des porte-greffes et des techniques de plantation. Des analyses géotechniques peuvent révéler des contraintes chimiques ou physiques à anticiper."
-  },
-  {
-    "date": "2024-07-28",
-    "target": "Structure grumeleuse",
-    "text": "La structure grumeleuse se compose d'agrégats arrondis et friables, riches en pores interconnectés qui favorisent l'infiltration et l'aération. Elle résulte d'une activité biologique intense.\n\nAu toucher, les agrégats se délitent facilement sans se compacter, signe d'une bonne cohésion organo-minérale. Les pores permettent une colonisation rapide par les racines fines.\n\nEn agronomie, maintenir une structure grumeleuse implique de limiter les passages d'engins par temps humide, d'apporter des matières organiques et de favoriser la vie du sol. Elle constitue la base d'un sol fertile et résilient."
-  },
-  {
-    "date": "2024-07-29",
-    "target": "Porosité macro",
-    "text": "La porosité macro correspond aux pores de grande taille qui assurent le drainage rapide de l'eau et la circulation de l'air. Ils se situent entre les agrégats ou dans les fissures du sol.\n\nCes vides se forment grâce à l'activité biologique, aux cycles de dessiccation et aux actions mécaniques comme le gel-dégel. Leur proportion influence la vitesse d'infiltration et la capacité d'aération.\n\nPour les agriculteurs, préserver la porosité macro suppose d'éviter le tassement et d'entretenir une couverture végétale aux racines vigoureuses. Un sol bien drainé limite les maladies racinaires et facilite le ressuyage."
-  },
-  {
-    "date": "2024-07-30",
-    "target": "Porosité micro",
-    "text": "La porosité micro rassemble les pores fins situés à l'intérieur des agrégats, capables de retenir l'eau contre la gravité. Ils constituent une réserve hydrique essentielle pour les plantes.\n\nCette porosité résulte de l'empilement des particules d'argile et de la présence de matière organique colloïdale. Elle évolue selon l'humidité et le stade de dessiccation du sol.\n\nEn conduite culturale, optimiser la porosité micro passe par un équilibre entre structure et teneur en matière organique. Trop compacte, elle bloque les échanges gazeux ; trop lâche, elle ne retient plus l'eau pour la culture."
-  },
-  {
-    "date": "2024-07-31",
-    "target": "Potentiel hydrique",
-    "text": "Le potentiel hydrique exprime l'énergie libre de l'eau dans un système, conditionnant les flux entre sol, plante et atmosphère. Les gradients orientent la circulation de l'eau depuis les zones humides vers les zones plus sèches.\n\nDans la plante, il résulte de la combinaison des potentiels osmotiques, matriciels et de pression. Les cellules ajustent leur turgescence en modulant les solutés internes pour maintenir un gradient favorable.\n\nEn agronomie, mesurer le potentiel hydrique des feuilles ou du sol aide à décider des irrigations et à anticiper les stress. Des outils comme la chambre à pression ou les sondes tensiométriques fournissent ces indicateurs."
-  },
-  {
-    "date": "2024-08-01",
-    "target": "Capillarité",
-    "text": "La capillarité permet à l'eau de remonter dans les pores fins du sol et les tissus végétaux grâce à la tension de surface. Elle maintient un continuum hydrique entre les horizons en l'absence de saturation.\n\nLes parois cellulosiques et les micropores du sol offrent des surfaces d'adhésion qui soutiennent ces mouvements. Des gradients de diamètre conduisent à des vitesses de flux différentes et conditionnent l'alimentation en eau.\n\nPour les cultures, la capillarité est essentielle dans les substrats fins ou les zones irriguées par submersion. Maintenir une structure de sol stable garantit des pores fonctionnels et évite les ruptures de colonne."
-  },
-  {
-    "date": "2024-08-02",
-    "target": "Transpiration foliaire",
-    "text": "La transpiration foliaire représente l'essentiel des pertes d'eau de la plante, assurant aussi le refroidissement et le transport des nutriments. Son intensité dépend de la lumière, de la température et du déficit de saturation de l'air.\n\nAu niveau des stomates, l'ouverture régule les flux, tandis que la cuticule contribue à une transpiration résiduelle. Les gradients de vapeur se déplacent à travers le parenchyme spongieux avant de quitter la feuille.\n\nPour les agriculteurs, suivre la transpiration aide à piloter l'irrigation et à dimensionner les serres ou filets d'ombrage. Des stress hydriques prolongés ferment les stomates et impactent directement la photosynthèse."
-  },
-  {
-    "date": "2024-08-03",
-    "target": "Photosynthèse C3",
-    "text": "La photosynthèse C3 est le mode majoritaire chez les plantes tempérées, fixant le CO₂ via la Rubisco dans le cycle de Calvin. Elle est sensible aux fortes températures et à la photorespiration.\n\nDans les cellules du mésophylle, les chloroplastes orchestrent la capture de lumière et la synthèse des trioses phosphates. La régénération du ribulose bisphosphate conditionne le débit de la chaîne.\n\nEn conduite culturale, optimiser la photosynthèse C3 passe par la gestion de la lumière, de l'azote et de l'eau pour limiter la photorespiration. Des variétés améliorées et des densités adaptées maximisent la biomasse produite."
-  },
-  {
-    "date": "2024-08-04",
-    "target": "Photosynthèse C4",
-    "text": "La photosynthèse C4 concentre le CO₂ avant son entrée dans le cycle de Calvin, réduisant la photorespiration et améliorant l'efficience en eau. Elle est caractéristique des graminées tropicales et de certaines adventices.\n\nLes cellules du mésophylle et de la gaine périvasculaire coopèrent via le cycle de Hatch-Slack, utilisant le malate et l'aspartate comme navettes. Cette partition anatomique confère une grande productivité en climat chaud.\n\nEn agriculture, les cultures C4 comme le maïs ou le sorgho valorisent mieux la lumière intense et l'eau limitée. Adapter la densité et les apports nutritifs permet d'exploiter ce potentiel élevé."
-  },
-  {
-    "date": "2024-08-05",
-    "target": "Métabolisme CAM",
-    "text": "Le métabolisme CAM stocke le CO₂ la nuit sous forme d'acides organiques pour le libérer le jour, permettant de fermer les stomates en période chaude. Il est typique des plantes succulentes des milieux arides.\n\nLes vacuoles accumulent le malate nocturne, tandis que les chloroplastes le décarboxylent le jour pour alimenter le cycle de Calvin. Les rythmes circadiens pilotent cette alternance.\n\nPour les producteurs de plantes ornementales ou aromatiques CAM, la gestion de l'arrosage et de la luminosité doit respecter ces rythmes. Des excès d'humidité peuvent perturber la fermeture nocturne des stomates."
-  },
-  {
-    "date": "2024-08-06",
-    "target": "Photorespiration",
-    "text": "La photorespiration survient lorsque la Rubisco fixe l'oxygène au lieu du CO₂, entraînant une perte d'énergie et de carbone. Ce phénomène s'accentue à forte température ou faible CO₂.\n\nElle implique un métabolisme complexe entre chloroplastes, peroxysomes et mitochondries pour recycler le phosphoglycolate. Malgré son coût, elle protège la cellule contre les excès d'énergie lumineuse.\n\nEn agronomie, limiter la photorespiration passe par le choix de variétés tolérantes, la gestion de l'ombrage et l'équilibre hydrique. Certaines pratiques de fertilisation azotée soutiennent la synthèse d'enzymes clés pour compenser ces pertes."
-  },
-  {
-    "date": "2024-08-07",
-    "target": "Respiration mitochondriale",
-    "text": "La respiration mitochondriale libère l'énergie des sucres produits par la photosynthèse, fournissant l'ATP nécessaire aux processus métaboliques. Elle se déroule dans la matrice et les crêtes des mitochondries.\n\nLes complexes de la chaîne respiratoire transfèrent les électrons vers l'oxygène en pompant des protons, générant un gradient utilisé par l'ATP synthase. Des voies alternatives permettent de dissiper l'excès d'énergie.\n\nDans les cultures, la respiration nocturne consomme une part du carbone accumulé le jour. Les stress thermiques ou hydriques modifient ce bilan, ce qui incite à ajuster les pratiques de récolte ou de stockage."
-  },
-  {
-    "date": "2024-08-08",
-    "target": "Glycolyse végétale",
-    "text": "La glycolyse végétale dégrade le glucose en pyruvate dans le cytosol, fournissant ATP et NADH pour la respiration. Elle constitue la première étape de l'utilisation des sucres.\n\nCertains intermédiaires servent à la synthèse d'acides aminés ou de lipides, rendant la glycolyse centrale dans le métabolisme. Des isoformes d'enzymes permettent une adaptation aux conditions d'oxygène variable.\n\nEn agronomie, la vigueur d'une culture dépend de l'équilibre entre production et utilisation des sucres. Des carences nutritives ou des stress limitent la glycolyse et se traduisent par une croissance ralentie."
-  },
-  {
-    "date": "2024-08-09",
-    "target": "Cycle de Calvin",
-    "text": "Le cycle de Calvin fixe le CO₂ pour produire des trioses phosphates, précurseurs des sucres et des réserves. Il dépend de l'activité de la Rubisco et de la régénération du ribulose bisphosphate.\n\nLes étapes de carboxylation, réduction et régénération se déroulent dans le stroma des chloroplastes, mobilisant ATP et NADPH issus des réactions lumineuses. Les régulations redox adaptent le cycle aux conditions de lumière.\n\nPour les agriculteurs, garantir une nutrition azotée et magnésienne adéquate soutient le cycle de Calvin et la productivité. Les stress qui réduisent l'activité enzymatique se traduisent rapidement par des baisses de rendement."
-  },
-  {
-    "date": "2024-08-10",
-    "target": "Photolyse de l'eau",
-    "text": "La photolyse de l'eau se produit dans le photosystème II, scindant l'eau en électrons, protons et oxygène sous l'effet de la lumière. Ce processus fournit les électrons nécessaires à la chaîne de transport.\n\nLe complexe d'évolution de l'oxygène contient des ions manganèse qui orchestrent les différentes étapes d'oxydation. Les protons libérés contribuent à la formation du gradient chimiosmotique.\n\nPour les cultures, assurer une bonne nutrition en manganèse et en lumière favorise une photolyse efficace. Des déficiences se traduisent par une baisse de photosynthèse et des chloroses."
-  },
-  {
-    "date": "2024-08-11",
-    "target": "Phototropisme",
-    "text": "Le phototropisme décrit l'orientation des organes en réponse à la lumière, favorisant la capture énergétique. Les tiges se courbent vers la source lumineuse grâce à une distribution asymétrique des auxines.\n\nLes photorécepteurs de type phototropines perçoivent les rayons bleus, déclenchant une cascade de signaux qui modifient la croissance cellulaire. Les cellules du côté ombré s'allongent davantage.\n\nEn conduite culturale, le phototropisme influence la densité de plantation et la gestion des éclairages artificiels. Des supports ou tuteurs sont parfois nécessaires pour canaliser ces courbures."
-  },
-  {
-    "date": "2024-08-12",
-    "target": "Gravitropisme",
-    "text": "Le gravitropisme oriente les racines vers le bas et les tiges vers le haut en réponse à la gravité. Des statolithes, amyloplastes denses, sédimentent dans des cellules spécialisées pour indiquer la direction.\n\nLes gradients d'auxine induits par ce signal modifient l'élongation cellulaire différemment dans les racines et les tiges. Un repositionnement rapide assure le maintien de la posture.\n\nEn agronomie, comprendre le gravitropisme aide à manipuler les semences, les boutures et les plants lors du repiquage. Des inversions prolongées peuvent perturber la croissance et réduire la vigueur."
-  },
-  {
-    "date": "2024-08-13",
-    "target": "Dormance des graines",
-    "text": "La dormance des graines empêche la germination immédiate après maturation, assurant un étalement dans le temps favorable à la survie. Elle dépend de barrières mécaniques, chimiques ou physiologiques.\n\nDes couches tégumentaires imperméables, des inhibiteurs internes ou une immaturité embryonnaire en sont responsables. Les conditions environnementales agissent comme signaux de levée de dormance.\n\nEn production de semences, gérer la dormance est essentiel pour garantir une germination homogène. Des traitements comme la scarification, la stratification ou l'utilisation de régulateurs permettent de la lever."
-  },
-  {
-    "date": "2024-08-14",
-    "target": "Germination",
-    "text": "La germination débute lorsque la graine absorbe l'eau et réactive son métabolisme, entraînant l'allongement de la radicule. La mobilisation des réserves nourrit les premiers stades jusqu'à l'autonomie photosynthétique.\n\nLes enzymes hydrolytiques libèrent les sucres, acides aminés et lipides stockés dans l'endosperme ou les cotylédons. La température, l'oxygène et l'humidité conditionnent la vitesse de ce processus.\n\nPour les agriculteurs, maîtriser la germination implique de soigner la qualité des semences, la préparation du lit de semis et la gestion de l'humidité. Des tests de pouvoir germinatif orientent les densités de semis."
-  },
-  {
-    "date": "2024-08-15",
-    "target": "Phytochrome",
-    "text": "Le phytochrome est un photorécepteur qui perçoit la lumière rouge et rouge lointain, régulant la germination, la floraison et la croissance. Il bascule entre deux formes selon la longueur d'onde reçue.\n\nCette protéine s'accumule dans le cytoplasme et le noyau, où elle interagit avec des facteurs de transcription pour moduler l'expression génique. Les rythmes circadiens en dépendent largement.\n\nEn horticulture, la manipulation du phytochrome via des éclairages spécifiques permet de contrôler la floraison ou l'allongement des tiges. Des écrans d'ombrage ou des LEDs adaptées sont utilisés."
-  },
-  {
-    "date": "2024-08-16",
-    "target": "Auxine",
-    "text": "L'auxine est une hormone végétale clé qui régule l'élongation cellulaire, la différenciation et la dominance apicale. Elle est synthétisée principalement dans les jeunes tissus.\n\nSon transport polarisé repose sur des transporteurs spécifiques comme PIN et AUX/LAX, créant des gradients fins. Ces flux orchestrent la formation des organes et la réponse aux stimuli.\n\nEn agriculture, les régulateurs de croissance à base d'auxine servent à favoriser l'enracinement des boutures, éclaircir les fruits ou contrôler l'émission des gourmands. Les doses doivent être précises pour éviter les phytotoxicités."
-  },
-  {
-    "date": "2024-08-17",
-    "target": "Cytokinine",
-    "text": "Les cytokinines stimulent la division cellulaire et retardent la sénescence des feuilles. Elles sont produites dans les racines et transportées vers les organes aériens.\n\nAu niveau moléculaire, elles activent des cascades de phosphorylation qui régulent l'expression de gènes liés au cycle cellulaire. Elles agissent souvent en interaction avec les auxines.\n\nPour les producteurs, l'application de cytokinines en foliaire peut maintenir la verdure et favoriser le remplissage des fruits. Elles interviennent aussi dans les protocoles de culture in vitro pour initier les bourgeons."
-  },
-  {
-    "date": "2024-08-18",
-    "target": "Acide abscissique",
-    "text": "L'acide abscissique (ABA) intervient dans la gestion du stress hydrique et la dormance des graines. Il s'accumule lors de la déshydratation et provoque la fermeture des stomates.\n\nLes récepteurs PYR/PYL déclenchent une cascade de signalisation qui active des facteurs de transcription spécifiques. L'ABA coordonne ainsi des réponses rapides et à long terme.\n\nEn agronomie, surveiller les niveaux d'ABA permet de comprendre la tolérance à la sécheresse et la maturation des fruits. Certaines pratiques culturale peuvent en moduler la synthèse ou la dégradation."
-  },
-  {
-    "date": "2024-08-19",
-    "target": "Éthylène",
-    "text": "L'éthylène est un gaz régulateur de croissance qui contrôle la maturation des fruits, la sénescence et les réponses au stress. Sa diffusion rapide permet une communication locale entre tissus.\n\nIl est synthétisé à partir de la méthionine via la voie de l'ACC et agit par l'intermédiaire de récepteurs membranaires spécifiques. Les réponses incluent des modifications d'expression génique et de structure cellulaire.\n\nPour les producteurs, la gestion de l'éthylène est cruciale lors du stockage et du transport des fruits climactériques. Des absorbeurs, des inhibiteurs comme le 1-MCP ou des ventilations adaptées limitent ses effets indésirables."
-  },
-  {
-    "date": "2024-08-20",
-    "target": "Jasmonate",
-    "text": "Les jasmonates sont des hormones impliquées dans les réponses de défense et la régulation de la croissance. Elles se synthétisent rapidement après une attaque d'herbivore ou un stress mécanique.\n\nLeur signalisation implique le complexe COI1-JAZ qui libère des facteurs de transcription spécifiques. Les métabolites dérivés diffusent dans la plante pour coordonner la réponse.\n\nEn agriculture, stimuler ou préserver la signalisation jasmonate peut renforcer la résistance naturelle des cultures. Des bio-intrants et des pratiques de stress léger sont parfois utilisés pour amorcer ces réponses."
-  },
-  {
-    "date": "2024-08-21",
-    "target": "Salicylate",
-    "text": "L'acide salicylique est au cœur des défenses systémiques acquises, notamment contre les pathogènes biotrophes. Il déclenche la production de protéines PR et l'établissement d'une mémoire immunitaire.\n\nLes chloroplastes et le cytosol participent à sa synthèse via plusieurs voies métaboliques. Des vagues de signalisation électrique et hormonale diffusent l'information dans la plante.\n\nPour les agriculteurs, surveiller l'état des défenses salicylées aide à anticiper la sensibilité aux maladies. Certains produits de biocontrôle visent à activer cette voie sans recourir à des pesticides chimiques."
-  },
-  {
-    "date": "2024-08-22",
-    "target": "Signal calcique",
-    "text": "Le signal calcique agit comme second messager universel dans les cellules végétales, traduisant les stimulations en réponses adaptées. Des variations de concentration cytosolique déclenchent des cascades de phosphorylation.\n\nDes canaux membranaires spécialisés contrôlent les entrées et sorties de calcium, tandis que des pompes et échangeurs rétablissent l'homéostasie. Les organites comme le réticulum ou la vacuole servent de réservoirs.\n\nEn physiologie végétale appliquée, comprendre le signal calcique permet d'améliorer la tolérance aux stress et d'ajuster des pulvérisations foliaires en calcium. Des outils de biologie moléculaire mesurent ces flux en temps réel."
-  },
-  {
-    "date": "2024-08-23",
-    "target": "Stromules",
-    "text": "Les stromules sont des tubules dynamiques émanant des chloroplastes, facilitant les échanges de métabolites et de signaux. Ils se déploient particulièrement en réponse aux stress ou aux besoins métaboliques accrus.\n\nLe cytosquelette d'actine guide leurs mouvements et favorise les contacts avec d'autres organites comme les mitochondries ou le noyau. Ils pourraient participer à la propagation de signaux de défense.\n\nDans les cultures, bien que non visibles à l'œil nu, les stromules témoignent d'une activité physiologique intense. La recherche agronomique s'y intéresse pour comprendre la coordination des réponses aux stress."
-  },
-  {
-    "date": "2024-08-24",
-    "target": "Plastoglobule",
-    "text": "Les plastoglobules sont des structures lipidiques présentes dans les chloroplastes, stockant des pigments et des lipides neutres. Ils jouent un rôle dans le recyclage des membranes thylakoïdales.\n\nIls contiennent des enzymes impliquées dans la synthèse de caroténoïdes et de tocophérols, molécules protectrices contre l'oxydation. Leur taille augmente lors de la sénescence ou d'un stress lumineux.\n\nEn production, la qualité nutritionnelle des fruits et légumes dépend en partie de ces composés lipidiques. Des conditions de culture équilibrées limitent la dégradation prématurée des plastoglobules."
-  },
-  {
-    "date": "2024-08-25",
-    "target": "Vacuole centrale",
-    "text": "La vacuole centrale occupe la majeure partie du volume cellulaire, stockant l'eau, les solutés et de nombreux métabolites. Elle contribue à la turgescence et au maintien de la forme cellulaire.\n\nSes membranes, le tonoplaste, contiennent des transporteurs spécialisés régulant le pH et la composition ionique. Des compartiments vacuolaires peuvent se spécialiser pour accumuler des pigments ou des composés de défense.\n\nEn horticulture, la gestion de l'irrigation et de la nutrition influe sur le remplissage vacuolaire et la fermeté des tissus récoltés. Des stress hydriques peuvent réduire la turgescence et provoquer des flétrissements."
-  },
-  {
-    "date": "2024-08-26",
-    "target": "Tonoplaste",
-    "text": "Le tonoplaste est la membrane qui entoure la vacuole et contrôle les échanges entre cytoplasme et compartiment vacuolaire. Il porte des pompes à protons, des antiporteurs et des canaux ioniques.\n\nSon activité maintient des gradients de pH et d'ions nécessaires au stockage des métabolites et à la détoxification. Des protéines aquaporines y régulent aussi les flux d'eau.\n\nPour les cultures, la performance du tonoplaste influe sur la tolérance aux stress salins ou métalliques. Des apports équilibrés en nutriments et la sélection variétale contribuent à sa robustesse."
-  },
-  {
-    "date": "2024-08-27",
-    "target": "Plasmodesme",
-    "text": "Les plasmodesmes relient les cellules végétales en traversant les parois, permettant le passage de signaux et de molécules. Ils créent un continuum cytoplasmique entre cellules adjacentes.\n\nUne membrane dérivée du réticulum endoplasmique, le desmotubule, occupe leur centre, tandis que l'ouverture latérale se régule par des dépôts de callose. La plante ajuste leur perméabilité selon les besoins.\n\nEn agronomie, la compréhension des plasmodesmes est cruciale pour lutter contre les virus qui les utilisent comme route de propagation. Des variétés résistantes ou des traitements ciblés cherchent à limiter ces déplacements."
-  },
-  {
-    "date": "2024-08-28",
-    "target": "Symplasme",
-    "text": "Le symplasme désigne l'ensemble des compartiments cellulaires reliés par les plasmodesmes, formant un réseau continu de transport. Les métabolites et hormones peuvent y circuler sans traverser les membranes plasmiques.\n\nCe réseau permet une coordination rapide des réponses physiologiques, notamment dans les tissus jeunes. Les barrières symplasmatiques peuvent se lever ou se renforcer selon les besoins.\n\nPour la conduite des cultures, favoriser une nutrition équilibrée soutient l'activité symplasmique et la distribution homogène des ressources. Des stress prolongés peuvent entraîner une fermeture de ces voies."
-  },
-  {
-    "date": "2024-08-29",
-    "target": "Apoplasme",
-    "text": "L'apoplasme correspond aux espaces extracellulaires et aux parois cellulaires, offrant une voie de transport sans franchir la membrane plasmique. Il joue un rôle dans la circulation de l'eau et des ions jusqu'à l'endoderme.\n\nDes dépôts de subérine au niveau de la bande de Caspary interrompent cette voie, obligeant un passage par le symplasme. Les interactions avec les composés de la paroi influencent la disponibilité des nutriments.\n\nEn agronomie, le fonctionnement de l'apoplasme conditionne l'efficacité des engrais foliaires et la distribution de certains pesticides systémiques. Des recherches visent à optimiser ces voies pour réduire les doses appliquées."
-  },
-  {
-    "date": "2024-08-30",
-    "target": "Transport actif",
-    "text": "Le transport actif déplace des solutés contre leur gradient de concentration en utilisant de l'énergie, souvent sous forme d'ATP. Il garantit la nutrition minérale même lorsque les concentrations externes sont faibles.\n\nDes pompes H⁺-ATPases établissent un gradient électrochimique qui alimente des symporteurs ou antiporteurs spécifiques. Ce mécanisme se retrouve dans les racines comme dans les feuilles.\n\nEn agronomie, la compréhension du transport actif permet d'optimiser les formulations d'engrais et les apports foliaires. Des applications trop concentrées peuvent saturer ces systèmes et provoquer des brûlures."
-  },
-  {
-    "date": "2024-08-31",
-    "target": "Osmorégulation",
-    "text": "L'osmorégulation correspond à la capacité des cellules à ajuster leur concentration interne en solutés pour maintenir la turgescence. Elle intervient face aux variations d'humidité ou de salinité.\n\nLes plantes accumulent des osmoprotecteurs comme les prolines ou les sucres solubles qui stabilisent les structures cellulaires. Les aquaporines modulent aussi les flux d'eau pour équilibrer les pressions.\n\nPour les cultures, soutenir l'osmorégulation implique une nutrition équilibrée et des stratégies anti-stress comme les biostimulants. Les variétés tolérantes sont sélectionnées pour leur capacité à maintenir ce contrôle."
-  },
-  {
-    "date": "2024-09-01",
-    "target": "Plasmolyse",
-    "text": "La plasmolyse survient lorsque la cellule perd de l'eau et que la membrane plasmique se détache de la paroi, conséquence d'un milieu externe hypertonique. Ce phénomène est souvent réversible si l'eau revient.\n\nAu microscope, on observe des poches d'eau se former et la membrane se rétracter autour du protoplaste. Les plasmodesmes se ferment temporairement pour protéger la cellule.\n\nEn post-récolte, éviter des solutions trop concentrées lors de traitements chimiques limite les plasmolyses irréversibles. Une gestion douce de la dessiccation préserve la qualité des produits."
-  },
-  {
-    "date": "2024-09-02",
-    "target": "Turgescence",
-    "text": "La turgescence maintient les tissus végétaux fermes grâce à la pression exercée par la vacuole sur la paroi cellulaire. Elle dépend de l'entrée d'eau dans la cellule via l'osmose.\n\nLes parois cellulosiques résistent à cette pression tout en permettant la croissance par relâchement contrôlé. Une turgescence suffisante est indispensable au maintien des feuilles et des tiges.\n\nEn horticulture, la turgescence conditionne l'aspect commercial des légumes-feuilles et des fleurs coupées. L'irrigation, la nutrition potassique et la fraîcheur après récolte sont des leviers pour la conserver."
-  },
-  {
-    "date": "2024-09-03",
-    "target": "Bois initial",
-    "text": "Le bois initial correspond aux premières cellules ligneuses produites au printemps, larges et à parois fines, favorisant la conduction rapide de la sève. Il contraste avec le bois d'été plus dense.\n\nLes vaisseaux y sont nombreux et de grand diamètre, ce qui rend la zone plus vulnérable aux embolies. Les anneaux de bois reflètent ainsi les conditions climatiques de croissance.\n\nEn foresterie et arboriculture, l'analyse du bois initial aide à comprendre la vigueur et l'historique hydrique des arbres. Des stress printaniers peuvent réduire sa formation et impacter la croissance annuelle."
-  },
-  {
-    "date": "2024-09-04",
-    "target": "Bois final",
-    "text": "Le bois final est formé en fin de saison de végétation et se compose de cellules plus petites à parois épaisses, renforçant la structure de la tige. Il confère densité et résistance mécanique.\n\nLes vaisseaux y sont moins nombreux, laissant davantage de fibres sclérifiées. Cette partie du cerne est souvent plus sombre et plus résistante aux insectes xylophages.\n\nPour les producteurs de bois ou de fruits, un bois final bien formé garantit la solidité des charpentes et la résistance aux vents. Les pratiques de taille et de nutrition influencent son développement."
-  },
-  {
-    "date": "2024-09-05",
+    "date": "2025-10-06",
     "target": "Cerne annuel",
     "text": "Le cerne annuel résulte de l'alternance entre bois initial et bois final, marquant une année de croissance. Il fournit des informations sur les conditions environnementales.\n\nLes variations d'épaisseur reflètent les fluctuations de ressources en eau, en nutriments ou les stress climatiques. La dendrochronologie utilise ces cernes pour reconstituer les climats passés.\n\nEn arboriculture, l'observation des cernes aide à diagnostiquer des accidents culturaux et à ajuster les itinéraires techniques. Une croissance régulière témoigne d'une conduite adaptée."
   },
   {
-    "date": "2024-09-06",
-    "target": "Phellogène",
-    "text": "Le phellogène est un méristème secondaire qui produit du liège vers l'extérieur et du phelloderme vers l'intérieur. Il remplace l'épiderme lorsque la tige s'épaissit.\n\nSes divisions périclines génèrent des tissus protecteurs imperméables et isolants. Son activité peut être cyclique selon les espèces et les saisons.\n\nEn arboriculture, préserver le phellogène est essentiel pour la cicatrisation des plaies et la qualité du liège chez le chêne-liège. Des blessures répétées peuvent perturber sa régénération."
-  },
-  {
-    "date": "2024-09-07",
-    "target": "Liège subéreux",
-    "text": "Le liège subéreux est un tissu mort produit par le phellogène, composé de cellules remplies d'air et de subérine. Il offre une protection thermique et hydrique à la plante.\n\nSes cellules polygonales empilées confèrent une grande compressibilité et une faible densité. Les couches successives s'accumulent et peuvent être récoltées chez certaines espèces.\n\nDans les cultures pérennes, un liège bien formé protège contre les agressions climatiques et les incendies. La récolte du liège nécessite une gestion fine pour ne pas endommager le phellogène."
-  },
-  {
-    "date": "2024-09-08",
-    "target": "Lignine",
-    "text": "La lignine rigidifie les parois secondaires des cellules, conférant résistance mécanique et imperméabilité. Elle s'accumule dans le xylème, les fibres et certains tissus de soutien.\n\nSa polymérisation résulte de la déhydrogénation de monolignols et se dépose entre les microfibrilles de cellulose. Elle limite la digestibilité des tissus par les herbivores et les micro-organismes.\n\nEn industrie et en agriculture, la lignine influence la qualité des fourrages, la transformation des fibres et la résistance des cultures aux pathogènes. Des variétés à lignification modifiée sont recherchées pour divers usages."
-  },
-  {
-    "date": "2024-09-09",
-    "target": "Cellulose",
-    "text": "La cellulose constitue le squelette des parois végétales, formant des microfibrilles résistantes et insolubles. Elle confère une grande solidité tout en permettant une certaine flexibilité.\n\nLes microfibrilles s'assemblent en faisceaux orientés, modulant la direction de la croissance cellulaire. Les complexes de cellulose synthase à la membrane plasmique orchestrent sa polymérisation.\n\nEn industrie agroalimentaire, la teneur en cellulose influence la texture des fibres et la digestibilité des fourrages. Des itinéraires techniques adaptés permettent de gérer son accumulation."
-  },
-  {
-    "date": "2024-09-10",
-    "target": "Hémicellulose",
-    "text": "Les hémicelluloses sont des polysaccharides ramifiés qui relient la cellulose à la matrice pectique. Elles contribuent à l'élasticité de la paroi.\n\nLeur composition varie selon les espèces, incluant des xylanes, mannane ou glucanes. Elles interagissent avec la lignine dans les parois secondaires.\n\nPour les technologies de transformation des fibres, l'extraction des hémicelluloses conditionne la qualité du papier ou des biomatériaux. En nutrition animale, elles participent à l'apport en fibres digestibles."
-  },
-  {
-    "date": "2024-09-11",
-    "target": "Pectine",
-    "text": "Les pectines sont des polysaccharides riches en acide galacturonique, responsables de la cohésion des parois primaires et de la texture des fruits. Elles forment des gels en présence de calcium.\n\nLa dé-méthylation des pectines par les enzymes pectinestérases modifie leur capacité de gélification. Les pectines participent aussi aux réponses de défense en relarguant des oligogalacturonides.\n\nEn industrie, la teneur en pectine influence la fermeté des fruits et la qualité des confitures. Les pratiques de récolte et de stockage visent à préserver ces polysaccharides."
-  },
-  {
-    "date": "2024-09-12",
-    "target": "Cutine",
-    "text": "La cutine est un polyester lipidique qui forme la matrice de la cuticule, limitant les pertes d'eau et protégeant contre les agressions. Elle s'associe à des cires pour créer une barrière hydrophobe.\n\nSon assemblage dépend de la synthèse d'acides gras hydroxylés et de leur polymérisation. Les gènes impliqués répondent aux stimuli lumineux et hydriques.\n\nPour les cultures, l'état de la cutine conditionne la résistance aux maladies foliaires et l'efficacité des traitements. Des pratiques culturales équilibrées soutiennent sa formation."
-  },
-  {
-    "date": "2024-09-13",
-    "target": "Subérine",
-    "text": "La subérine est un polymère aliphatique et aromatique présent dans le liège et les barrières apoplastiques. Elle bloque les flux d'eau et renforce la protection contre les pathogènes.\n\nElle s'accumule dans les cellules endodermiques, notamment lors de la formation de la bande de Caspary. Sa composition varie selon les stress subis.\n\nEn agronomie, la subérisation des racines influe sur l'absorption hydrique et la tolérance aux sels. Des stress hydriques modérés peuvent stimuler sa formation pour protéger la plante."
-  },
-  {
-    "date": "2024-09-14",
-    "target": "Paroi primaire",
-    "text": "La paroi primaire entoure les cellules en croissance, composée de cellulose, hémicellulose et pectine. Elle reste flexible pour permettre l'expansion cellulaire.\n\nDes protéines structurales comme les extensines et les expansines modulent son relâchement. Les plasmodesmes la traversent pour assurer la communication.\n\nEn physiologie végétale, comprendre la paroi primaire aide à manipuler la croissance des fruits et des tiges. Les hormones et la nutrition modifient sa composition et son extensibilité."
-  },
-  {
-    "date": "2024-09-15",
-    "target": "Paroi secondaire",
-    "text": "La paroi secondaire se dépose après la croissance, renforçant la cellule par des couches riches en cellulose et lignine. Elle confère une rigidité importante.\n\nLes trois couches S1, S2 et S3 présentent des orientations différentes de microfibrilles, optimisant la résistance mécanique. Des dépôts de lignine complètent la structure.\n\nPour les usages industriels du bois et des fibres, la qualité de la paroi secondaire détermine la solidité et la densité du matériau. Les conditions de croissance et les variétés influencent ces paramètres."
-  },
-  {
-    "date": "2024-09-16",
-    "target": "Collenchyme",
-    "text": "Le collenchyme est un tissu de soutien constitué de cellules vivantes aux parois épaissies de manière inégale. Il accompagne les organes en croissance et leur confère flexibilité.\n\nLes épaississements pectocellulosiques s'accumulent surtout aux angles cellulaires, autorisant l'allongement. Les cellules restent riches en protoplasme et peuvent se différencier ultérieurement.\n\nEn maraîchage, la vigueur des tiges charnues dépend du collenchyme. Des déséquilibres nutritionnels ou des stress hydriques peuvent affaiblir ce tissu et provoquer des cassures."
-  },
-  {
-    "date": "2024-09-17",
-    "target": "Sclérenchyme",
-    "text": "Le sclérenchyme comprend des cellules mortes à parois lignifiées très épaisses, assurant un soutien rigide. On distingue les fibres et les sclérides.\n\nLes fibres s'allongent pour former des faisceaux tandis que les sclérides donnent des structures plus courtes et épaisses. Les ponctuations permettent un minimum de circulation.\n\nEn agriculture, la proportion de sclérenchyme influence la texture des fruits, la rigidité des tiges et la qualité des fibres textiles. Des variétés sont sélectionnées pour adapter cette teneur."
-  },
-  {
-    "date": "2024-09-18",
-    "target": "Fibre libérienne",
-    "text": "Les fibres libériennes proviennent du phloème secondaire et constituent une matière première pour le textile. Elles sont longues, souples et résistantes.\n\nLeur maturation implique un renforcement de la paroi secondaire et une lignification partielle. Les procédés de rouissage et de teillage permettent de les isoler.\n\nPour les cultures de lin ou de chanvre, la qualité des fibres libériennes dépend de la densité de semis, de la nutrition et du moment de récolte. Un séchage maîtrisé préserve leurs propriétés."
-  },
-  {
-    "date": "2024-09-19",
-    "target": "Grain de pollen",
-    "text": "Le grain de pollen transporte les gamètes mâles et déclenche la reproduction chez les plantes à fleurs. Il est protégé par une exine résistante sculptée de motifs caractéristiques.\n\nÀ maturité, il déshydrate pour faciliter la dissémination puis réhydrate sur le stigmate compatible. Il renferme une cellule végétative et une cellule générative qui donnera deux spermatozoïdes.\n\nEn production fruitière, la qualité du pollen conditionne la nouaison. Les températures extrêmes, l'humidité ou les déficiences nutritives peuvent réduire sa viabilité."
-  },
-  {
-    "date": "2024-09-20",
-    "target": "Tube pollinique",
-    "text": "Le tube pollinique se développe à partir du grain de pollen germé et progresse dans le style pour atteindre l'ovule. Il constitue la voie d'acheminement des gamètes mâles.\n\nSa croissance est guidée par des gradients chimiques et structuraux produits par les tissus femelles. Le cytosquelette et les vésicules sécrétoires soutiennent cette extension rapide.\n\nPour les producteurs, la connaissance des facteurs influençant la croissance du tube pollinique aide à optimiser les conditions de pollinisation. Une humidité et une nutrition adaptées du pistil sont essentielles."
-  },
-  {
-    "date": "2024-09-21",
-    "target": "Double fécondation",
-    "text": "La double fécondation caractérise les angiospermes : un spermatozoïde fusionne avec l'oosphère pour former l'embryon, l'autre avec les noyaux polaires pour produire l'endosperme. Ce processus assure une synchronisation entre embryon et réserve nutritive.\n\nIl implique une coordination fine entre les cellules de l'ovule et les gamètes mâles. Des signaux moléculaires garantissent la reconnaissance et la fusion ciblée.\n\nEn amélioration variétale, maîtriser la double fécondation permet de produire des hybrides et de contrôler la formation des graines. Des pollinisations dirigées ou des manipulations d'ovules sont parfois nécessaires."
-  },
-  {
-    "date": "2024-09-22",
-    "target": "Albumen",
-    "text": "L'albumen constitue la réserve nutritive de nombreuses graines, alimentant l'embryon lors de la germination. Il est riche en amidon, protéines et lipides selon les espèces.\n\nSa texture et sa composition évoluent durant la maturation, influençant la qualité des farines ou des semences. Des enzymes mobilisent ces réserves lors de la germination.\n\nEn agroalimentaire, la valeur de l'albumen conditionne l'usage des céréales et des légumineuses. Les pratiques de fertilisation et les conditions de remplissage déterminent sa qualité."
-  },
-  {
-    "date": "2024-09-23",
-    "target": "Cotylédon",
-    "text": "Les cotylédons sont les feuilles embryonnaires qui stockent ou transfèrent les réserves vers l'embryon. Ils peuvent émerger au-dessus du sol ou rester souterrains selon les espèces.\n\nIls abritent des tissus nutritifs et des enzymes qui soutiennent les premières étapes de la germination. Leur morphologie est un critère d'identification des familles botaniques.\n\nEn pépinière, protéger les cotylédons contre les ravageurs et les stress garantit une implantation réussie. Leur santé influence la vigueur initiale de la plantule."
-  },
-  {
-    "date": "2024-09-24",
-    "target": "Endosperme",
-    "text": "L'endosperme est un tissu triploïde formé par la double fécondation, accumulant des réserves pour l'embryon. Il peut persister dans la graine mature ou être entièrement consommé.\n\nSes cellules se chargent de glucides, protéines et lipides, souvent disposés en couches distinctes. Des signaux hormonaux régulent sa croissance et sa dégradation.\n\nPour les cultures céréalières, la qualité de l'endosperme détermine le rendement et les usages industriels. Des conditions de remplissage optimales assurent un grain bien structuré."
-  },
-  {
-    "date": "2024-09-25",
-    "target": "Embryon",
-    "text": "L'embryon est l'organisme miniature contenu dans la graine, déjà organisé avec une radicule, une tigelle et des cotylédons. Il résulte de la fusion des gamètes.\n\nDurant la maturation, il accumule des réserves et acquiert une tolérance à la dessiccation. Des gènes spécifiques contrôlent son dormance et sa future germination.\n\nEn multiplication végétale, protéger l'embryon contre les stress thermiques et mécaniques est primordial. Des tests de coupe ou de coloration évaluent sa viabilité."
-  },
-  {
-    "date": "2024-09-26",
-    "target": "Tégument",
-    "text": "Le tégument entoure la graine et la protège contre les agressions physiques et biologiques. Il est issu des enveloppes de l'ovule et peut être imperméable.\n\nSa structure comprend souvent une couche externe cutinisée, une couche sclérifiée et des pigments. Il abrite parfois des composés inhibiteurs de la germination.\n\nEn agriculture, la qualité du tégument influence la conservation des semences et la levée de dormance. Des traitements appropriés assurent une germination homogène au semis."
-  },
-  {
-    "date": "2024-09-27",
-    "target": "Dormance tégumentaire",
-    "text": "La dormance tégumentaire provient d'une imperméabilité ou d'une résistance mécanique du tégument qui empêche l'entrée d'eau et d'oxygène. Elle retarde la germination jusqu'à la dégradation naturelle des barrières.\n\nDes cycles de gel-dégel, des passages dans le tube digestif ou l'action de micro-organismes lèvent progressivement cette dormance. Les couches lignifiées ou subérisées jouent un rôle clé.\n\nPour les techniciens de semences, diagnostiquer une dormance tégumentaire permet de choisir les traitements adéquats comme la scarification ou le trempage prolongé. Cela homogénéise l'émergence au champ."
-  },
-  {
-    "date": "2024-09-28",
-    "target": "Scarification",
-    "text": "La scarification consiste à altérer mécaniquement ou chimiquement le tégument des graines afin de lever la dormance tégumentaire. Elle augmente la perméabilité à l'eau.\n\nLes méthodes vont du frottement avec du papier abrasif au trempage dans des solutions acides contrôlées. Elles doivent être adaptées à l'épaisseur et à la fragilité du tégument.\n\nEn pépinière, la scarification est couramment utilisée pour les légumineuses ou les espèces ligneuses à graines dures. Un protocole précis évite les dommages à l'embryon tout en assurant une germination rapide."
-  },
-  {
-    "date": "2024-09-29",
-    "target": "Stratification froide",
-    "text": "La stratification froide expose les graines à une période humide et fraîche pour lever certaines dormances physiologiques. Elle simule les conditions hivernales naturelles.\n\nDurant ce traitement, les inhibiteurs internes se dégradent et les tissus embryonnaires poursuivent leur maturation. La durée et la température doivent être contrôlées avec précision.\n\nEn pépinière forestière ou horticole, la stratification froide assure une germination homogène au printemps. Des substrats propres et une surveillance régulière évitent les contaminations fongiques."
-  },
-  {
-    "date": "2024-09-30",
-    "target": "Levée de dormance",
-    "text": "La levée de dormance regroupe l'ensemble des processus qui permettent à une graine dormante de redevenir apte à germer. Elle dépend de signaux environnementaux et internes.\n\nLes changements de température, d'humidité, de photopériode ou les traitements chimiques modifient les hormones comme l'ABA et les gibberellines. Les tissus tégumentaires se ramollissent progressivement.\n\nPour les producteurs de plants, maîtriser la levée de dormance garantit des calendriers de semis fiables. Des tests préalables permettent d'ajuster les protocoles selon les lots."
-  },
-  {
-    "date": "2024-10-01",
-    "target": "Semis direct",
-    "text": "Le semis direct consiste à implanter les graines sans travail du sol profond, en conservant les résidus en surface. Il limite l'érosion et préserve la structure.\n\nLa gestion des couverts et des résidus est cruciale pour assurer un bon contact graine-sol et une levée rapide. Des semoirs spécifiques tranchent les résidus et déposent les graines à profondeur régulière.\n\nEn agriculture de conservation, le semis direct réduit les coûts de mécanisation et améliore la vie du sol. Il nécessite toutefois une maîtrise des adventices et de la fertilisation localisée."
-  },
-  {
-    "date": "2024-10-02",
-    "target": "Semoir monograine",
-    "text": "Le semoir monograine dépose les semences une par une à intervalles réguliers, assurant une population homogène. Il est indispensable pour les cultures de précision comme le maïs ou la betterave.\n\nSon organe de distribution peut être mécanique, pneumatique ou à dépression. Les réglages doivent prendre en compte la taille des graines et la vitesse d'avancement.\n\nPour les agriculteurs, un semoir monograine bien calibré optimise la levée et facilite les opérations ultérieures. L'entretien des éléments semeurs et des contrôles électroniques est essentiel."
-  },
-  {
-    "date": "2024-10-03",
-    "target": "Semoir pneumatique",
-    "text": "Le semoir pneumatique utilise l'air pour prélever, transporter et déposer les graines, offrant une grande polyvalence. Il s'adapte à des gammes variées de semences.\n\nDes disques perforés ou des chambres à dépression retiennent les graines avant de les relâcher au bon endroit. La pression d'air et le vide doivent être ajustés pour éviter les doublons ou les manques.\n\nEn grandes cultures, le semoir pneumatique permet des vitesses de chantier élevées tout en conservant une bonne précision. Un contrôle régulier des tuyaux et des flux d'air garantit une distribution uniforme."
-  },
-  {
-    "date": "2024-10-04",
-    "target": "Planteuse",
-    "text": "La planteuse mécanise la mise en place de plants, bulbes ou tubercules en respectant l'espacement désiré. Elle réduit la pénibilité et accroît la régularité des plantations.\n\nElle comporte des godets, cupules ou plateaux qui déposent le plant dans un sillon ouvert, avant de le refermer et d'assurer le rappuyage. Certains modèles combinent fertilisation ou irrigation localisée.\n\nPour les maraîchers et producteurs de pommes de terre, une planteuse bien réglée assure une implantation homogène et réduit les manques. L'alimentation régulière des plants et la qualité du lit de plantation restent déterminantes."
-  },
-  {
-    "date": "2024-10-05",
-    "target": "Buttage",
-    "text": "Le buttage consiste à ramener de la terre au pied des plantes pour protéger les organes sensibles, favoriser l'émission de racines adventives ou limiter les adventices. Il améliore aussi le drainage autour du pied.\n\nCette opération se réalise avec des buttoirs ou des disques qui forment des billons plus ou moins hauts. Elle doit être effectuée au bon stade pour éviter d'étouffer les jeunes pousses.\n\nEn cultures de pomme de terre, de maïs ou de légumes, le buttage est un levier pour sécuriser le rendement et la qualité. Il s'intègre dans un itinéraire combinant binages et fertilisation localisée."
-  },
-  {
-    "date": "2024-10-06",
-    "target": "Binage",
-    "text": "Le binage aère la couche superficielle du sol et détruit les adventices en sectionnant leurs jeunes pousses. Il améliore l'infiltration de l'eau et casse la croûte de battance.\n\nLes outils vont des houes rotatives aux bineuses guidées par caméra, permettant un travail précis entre les rangs. Le binage favorise aussi la minéralisation de la matière organique.\n\nPour les producteurs en agriculture biologique ou de conservation, le binage reste un outil majeur de gestion des adventices. Il se combine avec des couverts et des rotations diversifiées."
-  },
-  {
-    "date": "2024-10-07",
-    "target": "Sarclage",
-    "text": "Le sarclage enlève mécaniquement les adventices au voisinage immédiat des plantes, souvent à la main ou avec de petits outils. Il réduit la concurrence sans perturber fortement le sol.\n\nIl se pratique sur les lignes ou autour des plants, là où les outils de binage ne passent pas. Des sarclettes thermiques ou à lame oscillante complètent l'arsenal.\n\nEn maraîchage diversifié, un sarclage régulier maintient la propreté des planches et protège les cultures fragiles. Il demande une organisation rigoureuse pour intervenir au bon stade des adventices."
-  },
-  {
-    "date": "2024-10-08",
-    "target": "Paillage organique",
-    "text": "Le paillage organique recouvre le sol de matières végétales comme la paille, le foin ou le broyat. Il limite l'évaporation, réduit les adventices et nourrit la vie du sol en se décomposant.\n\nSa mise en place stabilise la température du sol et protège contre l'impact des pluies. Des apports réguliers maintiennent une couverture efficace tout au long du cycle.\n\nPour les agriculteurs et jardiniers, le paillage organique constitue un allié pour économiser l'eau et réduire les interventions mécaniques. Il favorise également la biodiversité fonctionnelle."
-  },
-  {
-    "date": "2024-10-09",
-    "target": "Mulch vivant",
-    "text": "Le mulch vivant consiste à maintenir une culture de couverture basse entre les rangs pour protéger le sol et limiter les adventices. Il reste vivant pendant le cycle de la culture principale.\n\nCe couvert apporte de la matière organique par ses racines et ses résidus, tout en hébergeant des auxiliaires. Sa gestion nécessite un contrôle de la concurrence hydrique et nutritive.\n\nEn viticulture ou en maraîchage, le mulch vivant améliore l'infiltration de l'eau et la portance. Des espèces adaptées et des tontes régulières garantissent son efficacité."
-  },
-  {
-    "date": "2024-10-10",
-    "target": "Engrais vert",
-    "text": "Les engrais verts sont des cultures temporaires destinées à être enfouies ou roulées pour enrichir le sol en matière organique et nutriments. Ils structurent également les profils.\n\nLes légumineuses fixent l'azote, tandis que les crucifères mobilisent des éléments comme le phosphore ou les nématicides naturels. Leur système racinaire améliore la porosité.\n\nEn rotation, les engrais verts réduisent les adventices, limitent l'érosion et apportent des bénéfices agronomiques durables. Leur choix se fait selon le climat, le type de sol et la culture suivante."
-  },
-  {
-    "date": "2024-10-11",
-    "target": "Plantes de service",
-    "text": "Les plantes de service sont implantées pour apporter un bénéfice agronomique spécifique, comme attirer des auxiliaires, repousser des ravageurs ou améliorer le sol. Elles cohabitent avec la culture.\n\nElles peuvent libérer des composés volatils répulsifs, fournir du nectar aux pollinisateurs ou couvrir le sol entre les rangs. Leur cycle est coordonné avec celui de la culture principale.\n\nEn systèmes intégrés, les plantes de service renforcent la résilience et réduisent la dépendance aux intrants. Un choix judicieux d'espèces et une gestion fine du couvert sont nécessaires."
-  },
-  {
-    "date": "2024-10-12",
-    "target": "Bande fleurie",
-    "text": "La bande fleurie est un aménagement permanent ou temporaire composé de plantes mellifères et nectarifères en bord de parcelle. Elle soutient les pollinisateurs et les auxiliaires.\n\nSa diversité floristique étalée dans le temps garantit un apport continu de ressources. Les structures verticales qu'elle offre servent aussi d'abris et de corridors écologiques.\n\nPour les exploitations, une bande fleurie bien gérée améliore la pollinisation, la lutte biologique et l'image environnementale. Elle peut bénéficier d'aides agroécologiques."
-  },
-  {
-    "date": "2024-10-13",
-    "target": "Lutte biologique",
-    "text": "La lutte biologique utilise des organismes vivants pour contrôler les ravageurs, qu'il s'agisse de prédateurs, parasitoïdes ou agents pathogènes. Elle s'intègre dans des stratégies durables.\n\nLa réussite dépend d'un diagnostic précis du ravageur, d'une sélection d'auxiliaires adaptés et d'un environnement favorable à leur installation. Des lâchers ou des conservations ciblées sont mis en place.\n\nEn agriculture, la lutte biologique réduit l'usage de pesticides et préserve les écosystèmes. Elle nécessite un suivi régulier et une formation technique des opérateurs."
-  },
-  {
-    "date": "2024-10-14",
-    "target": "Confusion sexuelle",
-    "text": "La confusion sexuelle consiste à diffuser des phéromones pour perturber l'accouplement des ravageurs. Elle réduit les populations sans intervention directe sur les individus.\n\nDes diffuseurs placés dans la parcelle créent un nuage odorant homogène qui empêche les mâles de localiser les femelles. Les formulations doivent être renouvelées selon leur durée d'action.\n\nEn viticulture et arboriculture, cette technique cible les lépidoptères comme la tordeuse ou le carpocapse. Elle s'associe à une surveillance continue pour vérifier l'efficacité."
-  },
-  {
-    "date": "2024-10-15",
-    "target": "Piégeage massif",
-    "text": "Le piégeage massif vise à capturer un grand nombre d'individus d'un ravageur pour réduire sa pression. Il utilise des appâts alimentaires, visuels ou phéromonaux.\n\nLes pièges doivent être disposés en nombre suffisant et entretenus régulièrement. Leur efficacité dépend de la période d'installation et de la densité de la population cible.\n\nDans les cultures maraîchères ou arboricoles, le piégeage massif complète la lutte biologique et chimique. Il permet de diminuer les seuils d'infestation avant l'apparition des dégâts."
-  },
-  {
-    "date": "2024-10-16",
-    "target": "Filet anti-insectes",
-    "text": "Les filets anti-insectes protègent les cultures en créant une barrière physique contre les ravageurs volants. Ils réduisent aussi l'impact du vent et de la grêle selon leur maille.\n\nLe choix de la densité de maille s'adapte au ravageur ciblé, tandis que l'installation doit garantir une bonne ventilation pour éviter les excès d'humidité. Des structures solides supportent le filet.\n\nPour les maraîchers, les filets anti-insectes sécurisent des cultures sensibles comme les brassicacées ou les cucurbitacées. Ils s'intègrent à une stratégie globale de protection."
-  },
-  {
-    "date": "2024-10-17",
-    "target": "Serre bioclimatique",
-    "text": "La serre bioclimatique optimise les échanges d'énergie pour réduire les besoins en chauffage ou refroidissement. Elle s'appuie sur l'inertie thermique, la ventilation naturelle et l'orientation.\n\nDes parois isolées, des murs à forte capacité thermique et des écrans mobiles régulent la température. La gestion de l'humidité et du CO₂ complète l'approche.\n\nPour les producteurs, une serre bioclimatique diminue les charges énergétiques et améliore la résilience face aux aléas climatiques. Elle nécessite une conception soignée et un pilotage précis."
-  },
-  {
-    "date": "2024-10-18",
-    "target": "Ombrière",
-    "text": "L'ombrère filtre la lumière pour protéger les cultures sensibles aux brûlures ou aux excès de rayonnement. Elle abaisse aussi la température et réduit la transpiration.\n\nLes filets d'ombrage existent en différents taux de coupure et couleurs pour moduler le spectre lumineux. Leur installation doit permettre une adaptation saisonnière.\n\nEn pépinière, en horticulture ornementale ou sous serre, les ombrières améliorent la qualité des plants et réduisent les stress. Elles se combinent à l'irrigation fine et à la ventilation."
-  },
-  {
-    "date": "2024-10-19",
-    "target": "Irrigation goutte-à-goutte",
-    "text": "L'irrigation goutte-à-goutte apporte l'eau au plus près des racines via des émetteurs localisés, limitant les pertes par évaporation. Elle permet de piloter finement les doses.\n\nLes débits se règlent en fonction du stade de la culture, de la texture du sol et du climat. Les réseaux nécessitent un filtrage et un entretien réguliers pour éviter l'obstruction des goutteurs.\n\nEn arboriculture, maraîchage ou horticulture, cette technique améliore l'efficience hydrique et permet la fertigation. Des sondes et des bilans hydriques assistent le pilotage."
-  },
-  {
-    "date": "2024-10-20",
-    "target": "Irrigation gravitaire",
-    "text": "L'irrigation gravitaire repose sur l'écoulement de l'eau par gravité dans des planches ou des sillons. Elle reste largement utilisée dans les régions disposant de ressources abondantes.\n\nLa maîtrise du nivellement, de la vitesse d'avancée et des volumes conditionne son efficacité. Des pertes par infiltration profonde ou ruissellement peuvent survenir.\n\nEn grande culture ou en riziculture, l'irrigation gravitaire reste économique mais demande une gestion précise pour limiter les gaspillages. Des aménagements de parcelles améliorent sa performance."
-  },
-  {
-    "date": "2024-10-21",
-    "target": "Irrigation par aspersion",
-    "text": "L'irrigation par aspersion distribue l'eau en gouttes fines projetées par des rampes, pivots ou canons. Elle imite une pluie artificielle.\n\nLe dimensionnement des buses, la pression et la vitesse d'avancement assurent une répartition homogène. Le vent et l'évaporation peuvent toutefois réduire l'efficacité.\n\nPour les agriculteurs, l'aspersion s'adapte à de nombreuses cultures et terrains. Son pilotage nécessite de surveiller les conditions météorologiques et la disponibilité en eau."
-  },
-  {
-    "date": "2024-10-22",
-    "target": "Sonde capacitive",
-    "text": "La sonde capacitive mesure la teneur en eau du sol en évaluant sa permittivité diélectrique. Elle fournit des données en continu pour piloter l'irrigation.\n\nInstallée à différentes profondeurs, elle renseigne sur l'évolution de l'humidité dans le profil. Les données peuvent être transmises à distance et intégrées dans des modèles de décision.\n\nEn agriculture de précision, les sondes capacitives permettent d'ajuster les apports d'eau, d'éviter les stress hydriques et de rationaliser l'énergie consommée par les systèmes d'irrigation."
-  },
-  {
-    "date": "2024-10-23",
-    "target": "Bilan hydrique",
-    "text": "Le bilan hydrique compare les apports d'eau (pluie, irrigation) aux pertes (évapotranspiration, drainage) pour déterminer les besoins de la culture. Il se calcule sur des périodes variables.\n\nDes modèles intègrent la météo, le stade de la plante, la réserve utile du sol et les caractéristiques variétales. Ils fournissent des recommandations d'irrigation.\n\nPour les exploitations, suivre le bilan hydrique aide à planifier les apports, sécuriser les rendements et économiser l'eau. Des outils numériques facilitent ces calculs."
-  },
-  {
-    "date": "2024-10-24",
-    "target": "Tension de succion",
-    "text": "La tension de succion correspond à l'effort nécessaire pour extraire l'eau du sol, mesurée avec des tensiomètres. Elle indique la facilité d'accès à l'eau pour les racines.\n\nLes tensiomètres placés dans le sol enregistrent la dépression créée par l'assèchement. Les seuils d'alarme varient selon les cultures et la texture.\n\nEn pilotage de l'irrigation, surveiller la tension de succion permet de déclencher les apports au moment opportun et d'éviter les stress ou les excès d'eau."
-  },
-  {
-    "date": "2024-10-25",
-    "target": "Stress hydrique",
-    "text": "Le stress hydrique survient lorsque la plante ne dispose pas d'eau suffisante pour maintenir sa turgescence et ses fonctions métaboliques. Il réduit la croissance et la production.\n\nLes symptômes vont du flétrissement à la réduction de la photosynthèse et au ralentissement du développement racinaire. Les hormones comme l'ABA se mobilisent.\n\nEn agronomie, anticiper le stress hydrique grâce à des outils de suivi et des stratégies d'irrigation permet de préserver le rendement. Des variétés tolérantes et des paillages limitent son impact."
-  },
-  {
-    "date": "2024-10-26",
-    "target": "Stress salin",
-    "text": "Le stress salin est provoqué par une concentration excessive de sels dans le sol ou l'eau, entraînant une réduction de l'absorption d'eau et des déséquilibres ioniques. Il affecte la croissance et la nutrition.\n\nLes plantes accumulent des ions toxiques comme le sodium et voient leur potentiel hydrique diminuer. Des mécanismes d'exclusion ou de compartimentation sont sollicités.\n\nPour les agriculteurs, gérer le stress salin implique de contrôler la qualité de l'eau d'irrigation, d'améliorer le drainage et de choisir des variétés tolérantes. Des amendements comme le gypse peuvent aider."
-  },
-  {
-    "date": "2024-10-27",
-    "target": "Salinité résiduelle",
-    "text": "La salinité résiduelle correspond aux sels accumulés dans le sol suite aux irrigations ou aux engrais, pouvant s'accroître au fil des saisons. Elle réduit la réserve utile en eau.\n\nDes analyses régulières du sol et de l'eau révèlent cette accumulation. Les sels se concentrent particulièrement en surface lors de l'évaporation.\n\nEn agriculture irriguée, gérer la salinité résiduelle nécessite des lessivages contrôlés, des rotations adaptées et une gestion fine des apports. Les systèmes de drainage contribuent à évacuer l'excès."
-  },
-  {
-    "date": "2024-10-28",
-    "target": "Drainage souterrain",
-    "text": "Le drainage souterrain utilise des tuyaux enterrés pour évacuer l'eau excédentaire des horizons saturés. Il améliore l'aération et la portance des sols.\n\nLes drains posés à intervalles réguliers recueillent l'eau et la dirigent vers des exutoires. Leur profondeur et leur espacement dépendent du sol et de la culture.\n\nPour les agriculteurs, un drainage souterrain bien conçu prévient l'asphyxie racinaire, facilite les interventions mécaniques et limite la dénitrification. Il s'accompagne d'un suivi de la qualité des rejets."
-  },
-  {
-    "date": "2024-10-29",
-    "target": "Drainage de surface",
-    "text": "Le drainage de surface évacue les excès d'eau par des fossés ou des modelages du terrain, évitant la stagnation. Il complète le drainage souterrain lorsque la nappe est superficielle.\n\nDes pentes légères orientent l'écoulement vers des collecteurs, tandis que des rigoles temporaires gèrent les fortes pluies. La végétalisation des fossés limite l'érosion.\n\nPour les exploitations, un drainage de surface bien conçu protège les cultures des asphyxies et permet l'accès rapide aux parcelles après pluie. Un entretien régulier est indispensable."
-  },
-  {
-    "date": "2024-10-30",
-    "target": "Tassement du sol",
-    "text": "Le tassement du sol résulte du passage répété d'engins ou de la pluie sur des sols nus, réduisant la porosité macro. Il freine l'enracinement et l'infiltration.\n\nLes horizons compactés présentent une densité apparente élevée et des fissures verticales limitées. La pénétration racinaire se concentre alors dans des galeries préexistantes.\n\nEn agronomie, prévenir le tassement passe par la limitation des charges à l'essieu, l'utilisation de pneus larges, le respect du ressuyage et la couverture permanente. Des diagnostics de résistance à la pénétration orientent les décisions."
-  },
-  {
-    "date": "2024-10-31",
-    "target": "Travail réduit",
-    "text": "Le travail réduit limite les passages d'outils et maintient une partie des résidus en surface. Il préserve la structure du sol et réduit la consommation de carburant.\n\nLes outils utilisés sont peu agressifs, comme les déchaumeurs à dents ou les strip-till qui ne perturbent que la ligne de semis. Les rotations doivent intégrer des cultures capables de gérer les résidus.\n\nPour les agriculteurs, le travail réduit s'accompagne d'une surveillance accrue des adventices et des ravageurs. Il constitue une étape vers l'agriculture de conservation."
-  },
-  {
-    "date": "2024-11-01",
-    "target": "Semis sous couvert",
-    "text": "Le semis sous couvert implante la culture principale dans un couvert vivant ou récemment détruit. Il protège le sol et améliore l'infiltration de l'eau.\n\nLes semoirs spécialisés ouvrent un sillon étroit et déposent la graine sans bouleverser le couvert. La gestion de la biomasse est cruciale pour éviter la concurrence.\n\nEn agriculture de conservation, le semis sous couvert réduit l'érosion, favorise la vie du sol et stabilise la température. Il demande un pilotage précis des couverts et des apports azotés."
-  },
-  {
-    "date": "2024-11-02",
-    "target": "Agriculture de conservation",
-    "text": "L'agriculture de conservation repose sur trois principes : couverture permanente du sol, travail minimal et rotations diversifiées. Elle vise à restaurer la fertilité et la biodiversité des sols.\n\nLes agriculteurs combinent des couverts végétaux, du semis direct et une gestion raisonnée des intrants. Des indicateurs biologiques et physiques suivent l'évolution du sol.\n\nCette approche réduit l'érosion, améliore la capacité d'infiltration et séquestre du carbone. Elle demande un changement global d'itinéraire technique et de matériel."
-  },
-  {
-    "date": "2024-11-03",
-    "target": "Agroforesterie",
-    "text": "L'agroforesterie associe arbres et cultures ou animaux sur une même parcelle, créant des interactions positives. Les arbres fournissent ombre, abris et services écosystémiques.\n\nLeur système racinaire explore des horizons complémentaires tandis que la litière enrichit le sol. Les haies ou alignements influencent le microclimat et la biodiversité.\n\nPour les exploitations, l'agroforesterie diversifie les productions, valorise les surfaces et renforce la résilience. Elle nécessite une planification soignée de l'espacement et des espèces."
-  },
-  {
-    "date": "2024-11-04",
-    "target": "Haie brise-vent",
-    "text": "La haie brise-vent protège les cultures et les élevages des vents dominants, réduisant l'évaporation et les dégâts mécaniques. Elle sert aussi d'abri à la faune auxiliaire.\n\nComposée d'espèces variées, elle étale la floraison et la fructification tout en offrant des strates de hauteur différentes. Son entretien inclut la taille et le renouvellement des plants.\n\nEn agriculture, une haie brise-vent bien placée améliore les microclimats, limite la dérive des produits phytosanitaires et stocke du carbone. Des dispositifs agro-environnementaux encouragent son implantation."
-  },
-  {
-    "date": "2024-11-05",
-    "target": "Ripisylve",
-    "text": "La ripisylve borde les cours d'eau et filtre les polluants issus des parcelles, stabilisant les berges. Elle abrite une biodiversité riche.\n\nLes racines maintiennent les sols, tandis que la litière ralentit les écoulements et favorise l'infiltration. Elle constitue un corridor écologique essentiel.\n\nPour les agriculteurs, préserver la ripisylve réduit les pertes de sol, améliore la qualité de l'eau et répond aux obligations réglementaires. Des programmes de restauration accompagnent son entretien."
-  },
-  {
-    "date": "2024-11-06",
-    "target": "Bande enherbée",
-    "text": "La bande enherbée est une zone permanente de graminées ou légumineuses laissée en bordure ou au cœur des parcelles. Elle intercepte les ruissellements et fournit un habitat aux auxiliaires.\n\nSa structure dense ralentit l'eau et piége les sédiments. Elle se fauche généralement une à deux fois par an pour maintenir sa fonction.\n\nDans les systèmes agricoles, les bandes enherbées s'intègrent aux dispositifs d'infrastructures agroécologiques. Elles participent à la conformité environnementale et à la lutte contre l'érosion."
-  },
-  {
-    "date": "2024-11-07",
-    "target": "Prairie permanente",
-    "text": "La prairie permanente reste en herbe pendant plusieurs années, offrant une couverture continue et des racines profondes. Elle séquestre du carbone et nourrit les troupeaux.\n\nSa flore diversifiée améliore la structure du sol, la biodiversité et la résilience face aux aléas climatiques. Les rotations de pâturage optimisent son potentiel.\n\nPour les éleveurs, la prairie permanente constitue une ressource fourragère stable et un support de services environnementaux. Une gestion raisonnée du pâturage et des apports organiques en assure la pérennité."
-  },
-  {
-    "date": "2024-11-08",
-    "target": "Prairie temporaire",
-    "text": "La prairie temporaire est implantée pour quelques années dans une rotation, apportant fourrage et améliorant le sol. Elle associe souvent graminées et légumineuses.\n\nSes racines densifient les horizons et fixent l'azote, tandis que la couverture limite l'érosion. Après retournement, elle laisse un sol structuré pour la culture suivante.\n\nPour les éleveurs et céréaliers, la prairie temporaire rétablit la fertilité et brise les cycles des adventices. Une gestion du pâturage et des coupes optimise sa valeur fourragère."
-  },
-  {
-    "date": "2024-11-09",
-    "target": "Rotation triennale",
-    "text": "La rotation triennale alterne trois cultures aux exigences différentes pour équilibrer les prélèvements et réduire les pressions parasitaires. Elle évite l'épuisement d'un élément nutritif.\n\nUn schéma classique associe une légumineuse, une céréale d'hiver et une culture de printemps. Chaque culture prépare le terrain pour la suivante.\n\nEn système agricole, une rotation triennale bien conçue améliore la fertilité, limite les adventices et lisse les risques économiques. Elle demande un suivi rigoureux des reliquats azotés."
-  },
-  {
-    "date": "2024-11-10",
-    "target": "Rotation légumineuse-céréale",
-    "text": "La rotation légumineuse-céréale exploite la capacité des légumineuses à fixer l'azote pour enrichir le sol avant une céréale. Elle optimise les apports d'azote minéral.\n\nLes résidus légumineux libèrent progressivement l'azote, réduisant les besoins de fertilisation de la culture suivante. Les maladies spécifiques sont également contenues.\n\nPour les agriculteurs, cette rotation améliore l'efficience azotée et la structure du sol. Elle s'accompagne d'une gestion fine des dates de semis et des destructions de couverts."
-  },
-  {
-    "date": "2024-11-11",
-    "target": "Culture intermédiaire",
-    "text": "La culture intermédiaire est implantée entre deux cultures principales pour couvrir le sol, capter les nitrates ou produire de la biomasse. Elle peut être restituée ou valorisée.\n\nLes espèces choisies s'adaptent au calendrier disponible et aux objectifs agronomiques : piège à nitrates, fourrage ou service structurel. Leur gestion détermine leur efficacité.\n\nEn agriculture durable, les cultures intermédiaires limitent les pertes d'azote, améliorent la structure et enrichissent la biodiversité. Elles nécessitent une planification précise de leur destruction."
-  },
-  {
-    "date": "2024-11-12",
-    "target": "Couverts gélifs",
-    "text": "Les couverts gélifs sont des espèces qui se détruisent naturellement avec le gel, facilitant le semis suivant sans intervention mécanique. Ils laissent une mulch protectrice.\n\nDes espèces comme la phacélie ou la moutarde sont utilisées pour leur croissance rapide et leur sensibilité au froid. Leur biomasse restitue des nutriments lors de la décomposition.\n\nPour les agriculteurs, les couverts gélifs simplifient l'itinéraire et limitent les coûts de destruction. Ils doivent être semés suffisamment tôt pour produire une biomasse efficace."
-  },
-  {
-    "date": "2024-11-13",
-    "target": "Couverts permanents",
-    "text": "Les couverts permanents restent en place plusieurs années, souvent dans les vergers ou vignobles, pour protéger le sol et favoriser la biodiversité. Ils demandent une gestion de la concurrence.\n\nDes espèces rustiques et tolérantes au piétinement sont choisies. Des tontes ou roulages réguliers maintiennent une hauteur compatible avec la culture principale.\n\nEn systèmes pérennes, les couverts permanents améliorent la portance, limitent l'érosion et servent d'habitat aux auxiliaires. Ils s'intègrent à la fertilisation organique."
-  },
-  {
-    "date": "2024-11-14",
-    "target": "Compostage",
-    "text": "Le compostage transforme les résidus organiques en un amendement stable riche en humus. Il s'effectue par une décomposition aérobie contrôlée.\n\nLa maîtrise du rapport carbone/azote, de l'humidité et de l'aération assure une montée en température suffisante pour hygiéniser le compost. Les retournements homogénéisent le processus.\n\nPour les exploitations, le compostage valorise les déchets organiques, réduit les achats d'engrais et améliore la structure du sol. Des analyses garantissent la qualité du produit fini."
-  },
-  {
-    "date": "2024-11-15",
-    "target": "Vermicompost",
-    "text": "Le vermicompost résulte de l'action de vers épigés qui transforment la matière organique en un amendement finement structuré. Il se produit à basse température.\n\nLes vers ingèrent les résidus pré-compostés et excrètent des turricules riches en nutriments et micro-organismes bénéfiques. Le processus nécessite une humidité et un pH contrôlés.\n\nEn maraîchage et horticulture, le vermicompost améliore la germination, la croissance et la résistance aux maladies. Il peut être utilisé en substrat ou en fertilisation liquide (thé de compost)."
-  },
-  {
-    "date": "2024-11-16",
-    "target": "Digestat",
-    "text": "Le digestat est le résidu issu de la méthanisation, contenant des nutriments minéralisés. Il se fractionne en phase liquide et solide.\n\nSa composition dépend des intrants du digesteur. Il nécessite un stockage étanche et une application raisonnée pour éviter les pertes par volatilisation ou lessivage.\n\nEn agriculture, le digestat remplace une partie des engrais minéraux et contribue au recyclage des effluents. Des plans d'épandage encadrent son utilisation."
-  },
-  {
-    "date": "2024-11-17",
-    "target": "Fertirrigation",
-    "text": "La fertirrigation combine fertilisation et irrigation en injectant des nutriments dans le réseau d'arrosage. Elle synchronise l'apport avec les besoins de la plante.\n\nDes solutions nutritives sont préparées selon les stades de croissance et contrôlées par des capteurs de conductivité. La qualité de l'eau et l'acidification éventuelle sont surveillées.\n\nPour les cultures sous serre, fruitières ou de plein champ irriguées, la fertirrigation optimise les rendements et réduit les pertes. Elle nécessite un matériel précis et des analyses régulières."
-  },
-  {
-    "date": "2024-11-18",
-    "target": "Fertilisation azotée",
-    "text": "La fertilisation azotée apporte l'azote nécessaire à la croissance végétative et à la production de protéines. Elle doit être synchronisée avec les stades clés de la culture.\n\nLes formes ammoniacales, nitriques ou uréiques présentent des vitesses d'assimilation différentes. Des fractionnements et des outils de pilotage optimisent leur efficacité.\n\nPour les agriculteurs, une fertilisation azotée raisonnée tient compte des reliquats, des apports organiques et des objectifs de rendement. Elle limite les pertes par volatilisation et lessivage."
-  },
-  {
-    "date": "2024-11-19",
-    "target": "Fertilisation phosphatée",
-    "text": "La fertilisation phosphatée fournit du phosphore, indispensable à la structure énergétique des cellules et à l'enracinement. Ce nutriment est peu mobile dans le sol.\n\nDes apports localisés ou des engrais starter favorisent son accès pour les jeunes plants. La solubilité dépend du pH et de la présence de calcium ou de fer.\n\nEn agronomie, gérer la fertilisation phosphatée implique d'analyser le sol, de choisir des formes adaptées et de favoriser la vie microbienne qui solubilise le phosphore. Les mycorhizes jouent un rôle clé."
-  },
-  {
-    "date": "2024-11-20",
-    "target": "Fertilisation potassique",
-    "text": "La fertilisation potassique soutient la régulation hydrique, la synthèse des sucres et la résistance aux stress. Le potassium active de nombreuses enzymes.\n\nIl est peu lessivable mais peut être retenu sur le complexe argilo-humique. Des apports en automne ou en pré-semis rechargent le sol.\n\nPour les cultures exigeantes comme la pomme de terre ou la betterave, une fertilisation potassique équilibrée assure qualité et rendement. Des analyses foliaires ajustent les doses en cours de cycle."
-  },
-  {
-    "date": "2024-11-21",
-    "target": "Chaux magnésienne",
-    "text": "La chaux magnésienne corrige l'acidité du sol tout en apportant du magnésium, élément central de la chlorophylle. Elle améliore la disponibilité des nutriments.\n\nSon épandage se planifie hors période de végétation active pour laisser le temps à la réaction de s'opérer. Le choix de granulométrie influence la vitesse d'action.\n\nPour les exploitations, l'utilisation de chaux magnésienne s'inscrit dans une stratégie d'amendement calco-magnésien, complétant la fertilisation et équilibrant le rapport Ca/Mg."
-  },
-  {
-    "date": "2024-11-22",
-    "target": "Amendement calcaire",
-    "text": "L'amendement calcaire élève le pH des sols acides et apporte du calcium. Il favorise la structure et l'activité biologique.\n\nDifférentes formes existent, de la craie aux carbonates broyés, avec des vitesses de réaction variables. Les doses se calculent selon la capacité tampon et la culture.\n\nEn agriculture, un amendement calcaire régulier évite les blocages de phosphore et améliore l'efficacité des engrais. Il se combine à des analyses de sol pour ajuster les apports."
-  },
-  {
-    "date": "2024-11-23",
-    "target": "Amendement organique",
-    "text": "Les amendements organiques, comme les fumiers ou composts, améliorent la matière organique, la structure et la biodiversité du sol. Ils libèrent des nutriments progressivement.\n\nLeur valeur agronomique dépend du rapport C/N, du degré de maturation et de la teneur en éléments nutritifs. Des plans d'épandage garantissent une répartition homogène.\n\nPour les agriculteurs, intégrer les amendements organiques dans la fertilisation réduit la dépendance aux engrais minéraux et accroît la résilience des sols. La traçabilité est essentielle."
-  },
-  {
-    "date": "2024-11-24",
-    "target": "Analyse foliaire",
-    "text": "L'analyse foliaire mesure les concentrations en nutriments dans les feuilles pour diagnostiquer l'état nutritionnel des cultures. Elle complète les analyses de sol.\n\nDes prélèvements standardisés à des stades précis assurent des résultats comparables. Les interprétations s'appuient sur des références variétales.\n\nEn arboriculture, viticulture ou grandes cultures, l'analyse foliaire permet d'ajuster les apports en cours de cycle. Elle détecte les carences latentes avant l'apparition de symptômes."
-  },
-  {
-    "date": "2024-11-25",
-    "target": "Observation au champ",
-    "text": "L'observation au champ consiste à parcourir régulièrement les parcelles pour repérer les stades de développement, les adventices, les ravageurs et les maladies. C'est la base du pilotage agronomique.\n\nElle associe des observations visuelles, des notations et parfois des prélèvements pour analyses. Les outils numériques facilitent la consignation des données.\n\nPour les agriculteurs et conseillers, une observation rigoureuse permet des interventions ciblées, évite les traitements inutiles et améliore la compréhension du comportement des cultures."
-  },
-  {
-    "date": "2024-11-26",
-    "target": "Modélisation phénologique",
-    "text": "La modélisation phénologique prédit les stades de développement des plantes en fonction des conditions climatiques. Elle s'appuie sur des cumuls de chaleur ou des modèles plus complexes.\n\nDes courbes de calibration par variété permettent d'ajuster les modèles. Les données météo locales sont essentielles pour la précision.\n\nEn agriculture, la modélisation phénologique aide à planifier les travaux, les traitements et les récoltes. Elle s'intègre dans des outils d'aide à la décision connectés."
-  },
-  {
-    "date": "2024-11-27",
-    "target": "Somme de températures",
-    "text": "La somme de températures cumule les degrés-jours au-dessus d'un seuil pour estimer la progression du cycle végétatif. Elle sert de base à de nombreux modèles phénologiques.\n\nChaque culture possède des seuils de base et des besoins en degrés-jours spécifiques. Les variations climatiques modulent l'accumulation.\n\nPour les producteurs, suivre la somme de températures aide à positionner les interventions, anticiper les risques de ravageurs et programmer les récoltes. Des stations météo locales fournissent ces données en continu."
-  },
-  {
-    "date": "2024-11-28",
-    "target": "Indice foliaire (LAI)",
-    "text": "L'indice foliaire mesure la surface de feuilles par unité de surface de sol, évaluant la densité du couvert végétal. Il sert à estimer la capture de lumière et l'évapotranspiration.\n\nDes capteurs optiques ou des méthodes destructives permettent de le mesurer. Les modèles de croissance utilisent le LAI pour ajuster leurs prédictions.\n\nEn agriculture, suivre le LAI aide à optimiser les densités de semis, les apports azotés et les interventions phytosanitaires. Il renseigne sur l'état de santé du couvert."
-  },
-  {
-    "date": "2024-11-29",
-    "target": "Indice de verdure NDVI",
-    "text": "Le NDVI est un indice spectral basé sur la réflexion du rouge et du proche infrarouge, indiquant la vigueur et la biomasse du végétal. Il varie de -1 à 1.\n\nLes satellites, drones ou capteurs embarqués fournissent des cartes de NDVI à différentes échelles. Les variations temporelles détectent les stress précoces.\n\nPour les exploitations, le NDVI permet de zoner les parcelles, d'ajuster les doses d'engrais et d'identifier les zones à risque. Il s'intègre dans les outils d'agriculture de précision."
-  },
-  {
-    "date": "2024-11-30",
-    "target": "Cartographie de rendement",
-    "text": "La cartographie de rendement enregistre la production récoltée en chaque point du champ grâce à des capteurs sur les moissonneuses. Elle révèle l'hétérogénéité intra-parcellaire.\n\nLes données combinées à la géolocalisation permettent de repérer les zones à fort potentiel ou en difficulté. Des corrections de capteurs sont nécessaires pour fiabiliser les mesures.\n\nEn agronomie, analyser les cartes de rendement oriente les décisions de fertilisation variable, d'aménagement du sol et de sélection variétale. Elles servent de base au conseil de précision."
-  },
-  {
-    "date": "2024-12-01",
-    "target": "Capteur d’éclairement",
-    "text": "Les capteurs d'éclairement mesurent l'intensité lumineuse reçue par la culture, en lux ou en µmol·m⁻²·s⁻¹. Ils évaluent l'efficacité de l'éclairage naturel ou artificiel.\n\nDes capteurs quantiques ou photométriques sont installés à hauteur de canopée pour suivre les variations journalières. Les données guident les ajustements d'ombrage ou d'éclairage.\n\nDans les serres et les cultures indoor, ces capteurs optimisent la photosynthèse tout en limitant la consommation énergétique. Ils s'intègrent aux systèmes de pilotage climatique."
-  },
-  {
-    "date": "2024-12-02",
-    "target": "Station météo connectée",
-    "text": "La station météo connectée collecte en continu des données locales de température, humidité, vent, pluie et rayonnement. Elle transmet ces informations vers des plateformes en ligne.\n\nDes capteurs spécifiques peuvent suivre la tension de surface foliaire, l'humectation ou la température du sol. Les données alimentent des modèles de maladies ou d'irrigation.\n\nPour les agriculteurs, une station connectée fournit des alertes personnalisées, améliore la planification des travaux et documente les pratiques pour la traçabilité."
-  },
-  {
-    "date": "2024-12-03",
-    "target": "Piège à phéromones",
-    "text": "Les pièges à phéromones attirent les insectes mâles grâce à des molécules mimant les émissions femelles. Ils permettent de suivre les populations et de déclencher les interventions.\n\nLeur design varie selon l'espèce ciblée, avec des pièges delta, entonnoir ou à eau. Les capsules de phéromones doivent être renouvelées régulièrement.\n\nEn protection intégrée, les pièges à phéromones servent d'outils de surveillance ou de lutte directe. Ils réduisent le recours aux insecticides en ciblant les périodes critiques."
-  },
-  {
-    "date": "2024-12-04",
-    "target": "Outil d’aide à la décision",
-    "text": "Les outils d'aide à la décision agrègent des données agronomiques, météorologiques et économiques pour proposer des recommandations. Ils peuvent être spécialisés par culture ou par thème.\n\nIls intègrent des modèles, des seuils d'alerte et des scénarios économiques. Les interfaces web ou mobiles facilitent leur utilisation sur le terrain.\n\nPour les exploitations, ces outils sécurisent les décisions, optimisent les intrants et améliorent la traçabilité. Leur performance dépend de la qualité des données saisies."
-  },
-  {
-    "date": "2024-12-05",
-    "target": "Itinéraire technique",
-    "text": "L'itinéraire technique décrit l'ensemble des opérations réalisées sur une culture, de la préparation du sol à la récolte. Il intègre les choix variétaux, les apports et les interventions.\n\nChaque étape est planifiée selon des objectifs agronomiques, économiques et environnementaux. Des ajustements sont faits en fonction des observations au champ.\n\nPour les agriculteurs, formaliser l'itinéraire technique facilite l'analyse des performances, la communication avec les conseillers et la conformité réglementaire."
-  },
-  {
-    "date": "2024-12-06",
-    "target": "Plante compagne",
-    "text": "Une plante compagne est associée à la culture principale pour apporter un service : soutien physique, attraction des pollinisateurs ou contrôle des ravageurs. Elle est semée simultanément ou peu après.\n\nElle peut servir de tuteur vivant, libérer des composés bénéfiques ou couvrir le sol pour limiter les adventices. Sa densité et sa conduite sont ajustées pour éviter la concurrence.\n\nEn maraîchage et en grandes cultures, les plantes compagnes améliorent la résilience et l'efficience des systèmes. Des expérimentations locales déterminent les meilleures associations."
-  },
-  {
-    "date": "2024-12-07",
-    "target": "Association maïs-haricot",
-    "text": "L'association maïs-haricot combine une céréale haute servant de tuteur et une légumineuse grimpante fixant l'azote. Elle s'inspire des systèmes traditionnels d'agriculture associée.\n\nLe maïs offre un support pour le haricot, tandis que ce dernier enrichit le sol en azote et diversifie la production. Les dates de semis doivent être coordonnées pour éviter la concurrence précoce.\n\nPour les agriculteurs en agroécologie, cette association augmente la résilience, favorise la couverture du sol et offre des récoltes complémentaires. Elle requiert une gestion attentive des densités et de la récolte."
-  },
-  {
-    "date": "2024-12-08",
-    "target": "Système riz-poisson",
-    "text": "Le système riz-poisson associe la riziculture et l'élevage de poissons dans les mêmes parcelles inondées. Les poissons valorisent les ressources aquatiques et contrôlent certains ravageurs.\n\nLeurs mouvements aèrent l'eau, recyclent les résidus et apportent des nutriments via leurs déjections. Le riz bénéficie d'une fertilisation naturelle et d'une réduction des larves d'insectes.\n\nPour les producteurs, ce système diversifie les revenus et améliore l'efficience de l'eau. Il demande une conception adaptée des parcelles et un suivi sanitaire des poissons."
-  },
-  {
-    "date": "2024-12-09",
-    "target": "Culture sur butte",
-    "text": "La culture sur butte élève la ligne de plantation pour améliorer le drainage, la structure et le réchauffement du sol. Elle est utilisée en maraîchage ou en agroforesterie tropicale.\n\nLes buttes peuvent être permanentes ou temporaires, associées à des apports de matière organique et à des paillages. Elles favorisent l'activité biologique et la profondeur racinaire.\n\nEn zones humides ou lourdes, la culture sur butte évite l'asphyxie des racines et permet des récoltes plus précoces. Elle demande un entretien pour maintenir les formes et les chemins."
-  },
-  {
-    "date": "2024-12-10",
-    "target": "Culture hydroponique",
-    "text": "La culture hydroponique cultive les plantes hors sol dans une solution nutritive contrôlée. Les racines sont suspendues ou supportées dans un substrat neutre.\n\nLa composition de la solution, le pH, l'oxygénation et la température doivent être surveillés en continu. Les systèmes peuvent être en flux continu, NFT ou en goutte-à-goutte.\n\nPour les serristes, l'hydroponie offre des rendements élevés, une maîtrise sanitaire et une consommation d'eau réduite. Elle nécessite un investissement technologique et une expertise technique."
-  },
-  {
-    "date": "2024-12-11",
-    "target": "Aéroponie",
-    "text": "L'aéroponie cultive les plantes sans substrat, en pulvérisant périodiquement une solution nutritive sur les racines suspendues. Elle maximise l'oxygénation racinaire.\n\nLes buses de brumisation, la conductivité et la désinfection de l'eau sont des paramètres critiques. Les racines sont protégées de la lumière pour éviter l'oxydation.\n\nEn production de plants et de semences, l'aéroponie accélère la croissance, améliore la qualité sanitaire et réduit l'utilisation de substrats. Elle demande une alimentation électrique sécurisée."
-  },
-  {
-    "date": "2024-12-12",
-    "target": "Culture en substrat coco",
-    "text": "La culture en substrat coco utilise des fibres de coco comme support inerte pour les plantes. Ce substrat possède une bonne rétention d'eau et une aération élevée.\n\nIl nécessite un arrosage fréquent avec une solution nutritive équilibrée et une gestion du drainage pour éviter l'accumulation de sels. La réutilisation impose une désinfection rigoureuse.\n\nPour les horticulteurs, la fibre de coco offre une alternative renouvelable à la tourbe. Elle s'adapte aux cultures hors sol comme la fraise ou la tomate."
-  },
-  {
-    "date": "2024-12-13",
-    "target": "Substrat laine de roche",
-    "text": "La laine de roche est un substrat minéral utilisé en culture hors sol, issu du basalte fondu et filé. Elle offre une grande porosité et une uniformité de production.\n\nLes plaques ou cubes sont irrigués par des solutions nutritives contrôlées. Le suivi de l'humidité et de l'EC dans le substrat est indispensable.\n\nEn horticulture sous serre, la laine de roche assure une croissance régulière et des rendements élevés. La gestion de la fin de cycle et du recyclage du substrat reste un enjeu environnemental."
-  },
-  {
-    "date": "2024-12-14",
-    "target": "Culture verticale",
-    "text": "La culture verticale superpose plusieurs niveaux de production, souvent en environnement contrôlé. Elle maximise la productivité au mètre carré.\n\nL'éclairage LED, la gestion climatique et les systèmes hydroponiques ou aéroponiques sont intégrés dans des tours ou étagères. Les flux d'air et de nutriments sont finement pilotés.\n\nPour les producteurs urbains, la culture verticale offre une production de proximité, une traçabilité élevée et une faible consommation d'eau. Elle nécessite un investissement initial important et une maintenance continue."
-  },
-  {
-    "date": "2024-12-15",
-    "target": "Lumière artificielle horticole",
-    "text": "L'éclairage horticole artificiel fournit une lumière adaptée à la photosynthèse lorsque l'éclairement naturel est insuffisant. Les technologies LED permettent de moduler le spectre et l'intensité.\n\nLes plantes répondent différemment aux longueurs d'onde bleu, rouge ou far-red. Des programmes lumineux ajustés soutiennent la croissance, la floraison ou la fructification.\n\nEn cultures indoor ou sous serre, la lumière artificielle prolonge les photopériodes, assure une production hivernale et améliore la qualité des plantes. Elle s'inscrit dans un pilotage énergétique précis."
-  },
-  {
-    "date": "2024-12-16",
-    "target": "Photopériode contrôlée",
-    "text": "La photopériode contrôlée ajuste la durée du jour perçue par la plante pour déclencher la floraison ou le repos végétatif. Des écrans ou éclairages spécifiques modulent la lumière.\n\nLes plantes de jours courts ou de jours longs réagissent différemment à ces manipulations. Des cycles de lumière interrompue peuvent maintenir la croissance végétative.\n\nEn horticulture ornementale ou en production de plants, contrôler la photopériode synchronise la floraison et répond à la demande du marché. Cela nécessite des installations de fermeture ou d'éclairage programmables."
-  },
-  {
-    "date": "2024-12-17",
-    "target": "Tablette de multiplication",
-    "text": "La tablette de multiplication est un support chauffé et humidifié utilisé pour l'enracinement des boutures ou la germination. Elle crée un microclimat favorable et stable.\n\nDes câbles chauffants, des brumisateurs et des thermostats maintiennent des conditions optimales de température et d'humidité. Des capots transparents protègent des courants d'air.\n\nPour les pépiniéristes, une tablette de multiplication améliore le taux de reprise, accélère l'enracinement et uniformise la production. Elle facilite les séries successives de boutures."
-  },
-  {
-    "date": "2024-12-18",
-    "target": "Brumisation",
-    "text": "La brumisation diffuse de fines gouttelettes d'eau pour maintenir une humidité élevée autour des plantes sans détremper le substrat. Elle limite les stress hydriques et thermiques.\n\nDes buses spécifiques et des programmateurs régulent la fréquence et la durée des cycles. L'eau doit être filtrée pour éviter l'encrassement et les dépôts.\n\nEn pépinière, en serre ou en salle de culture, la brumisation améliore la reprise des boutures, la germination et le confort des plants. Elle s'intègre au pilotage climatique."
-  },
-  {
-    "date": "2024-12-19",
-    "target": "Calage variétal",
-    "text": "Le calage variétal consiste à choisir les variétés adaptées au terroir, aux contraintes climatiques et au marché. Il prend en compte les cycles, les résistances et la qualité.\n\nDes essais comparatifs, des réseaux d'expérimentation et des retours de terrain alimentent le choix. Les caractéristiques recherchées évoluent avec les attentes des filières.\n\nPour les agriculteurs, un calage variétal pertinent sécurise le rendement, la précocité et la valorisation commerciale. Il s'actualise régulièrement face aux nouveaux cultivars."
-  },
-  {
-    "date": "2024-12-20",
-    "target": "Sélection participative",
-    "text": "La sélection participative associe agriculteurs, techniciens et chercheurs pour co-sélectionner des variétés répondant aux besoins locaux. Elle valorise les savoirs empiriques.\n\nLes essais sont conduits directement sur les exploitations, avec une observation fine des comportements en conditions réelles. Les critères incluent la résilience, le goût et la facilité de conduite.\n\nCette approche favorise l'adoption des innovations, la diversité génétique et l'autonomie semencière. Elle crée un lien étroit entre recherche et terrain."
-  },
-  {
-    "date": "2024-12-21",
-    "target": "Banque de semences",
-    "text": "Les banques de semences conservent des échantillons de ressources génétiques pour préserver la diversité végétale. Elles stockent les graines dans des conditions contrôlées de température et d'humidité.\n\nDes protocoles de régénération et de duplication garantissent la viabilité à long terme. Les accès sont documentés avec des passeports génétiques et des informations agronomiques.\n\nPour l'agriculture, les banques de semences fournissent des ressources pour la sélection, la recherche et la restauration des variétés locales. Elles constituent un patrimoine commun."
-  },
-  {
-    "date": "2024-12-22",
-    "target": "Conservation in situ",
-    "text": "La conservation in situ maintient les plantes dans leur environnement naturel ou dans les systèmes agricoles traditionnels. Elle conserve les interactions écologiques et les évolutions adaptatives.\n\nLes agriculteurs gardiens de semences jouent un rôle clé en cultivant des variétés locales année après année. Les politiques publiques soutiennent ces pratiques.\n\nCette conservation vivante assure une adaptation continue aux changements climatiques et aux pressions sanitaires. Elle complète les banques ex situ."
-  },
-  {
-    "date": "2024-12-23",
-    "target": "Micropropagation",
-    "text": "La micropropagation multiplie rapidement des plantes en laboratoire à partir de tissus méristématiques ou de fragments. Elle produit des plants sains et uniformes.\n\nLes explants sont cultivés sur des milieux gélifiés stériles contenant nutriments et hormones. Des phases de multiplication, d'enracinement et d'acclimatation se succèdent.\n\nEn horticulture et arboriculture, la micropropagation fournit des plants indemnes de virus, accélère la diffusion de nouvelles variétés et sécurise la production de porte-greffes."
-  },
-  {
-    "date": "2024-12-24",
-    "target": "Culture de tissus",
-    "text": "La culture de tissus regroupe les techniques de culture in vitro de cellules, de tissus ou d'organes végétaux. Elle permet la régénération de plantes entières à partir de quelques cellules.\n\nLes conditions aseptiques, les milieux nutritifs et les régulateurs de croissance déterminent la réussite. Des callus se forment avant de se différencier en organes.\n\nCette technologie sert à la multiplication, à la conservation et à l'amélioration génétique. Elle ouvre la voie à la production de métabolites d'intérêt."
-  },
-  {
-    "date": "2024-12-25",
-    "target": "Cryoconservation",
-    "text": "La cryoconservation préserve du matériel végétal à très basse température, souvent dans l'azote liquide, pour une conservation à long terme. Elle s'applique aux embryons, bourgeons ou graines.\n\nDes protocoles de prétraitement et de cryoprotection évitent la formation de cristaux de glace destructeurs. Le matériel est stocké dans des cryotanks sécurisés.\n\nPour les banques de ressources génétiques, la cryoconservation assure une sauvegarde durable et indépendante des aléas climatiques ou politiques. Elle complète les collections vivantes."
-  },
-  {
-    "date": "2024-12-26",
-    "target": "Ressource phytogénétique",
-    "text": "Les ressources phytogénétiques regroupent l'ensemble des variétés cultivées, des espèces sauvages apparentées et des collections conservées. Elles constituent la base de l'amélioration variétale.\n\nLeur gestion implique des inventaires, des banques de gènes et des programmes de valorisation. La propriété intellectuelle et l'accès aux ressources sont encadrés par des accords internationaux.\n\nPour la sécurité alimentaire, préserver les ressources phytogénétiques garantit la capacité à développer des variétés résilientes face aux nouvelles contraintes. Des réseaux internationaux coordonnent ces efforts."
-  },
-  {
-    "date": "2024-12-27",
-    "target": "Lutte intégrée",
-    "text": "La lutte intégrée combine des méthodes agronomiques, biologiques, physiques et chimiques pour contrôler les ravageurs avec un impact minimal sur l'environnement. Elle repose sur la prévention et la surveillance.\n\nLes stratégies incluent la rotation, les variétés résistantes, la lutte biologique, les seuils d'intervention et l'usage raisonné des pesticides. L'observation régulière est indispensable.\n\nEn agriculture durable, la lutte intégrée réduit les coûts et les risques, tout en maintenant la qualité des récoltes. Elle nécessite une formation continue et un réseau d'alerte efficace."
-  },
-  {
-    "date": "2024-12-28",
-    "target": "Niveau d’infestation seuil",
-    "text": "Le niveau d’infestation seuil correspond à la densité de ravageurs à partir de laquelle une intervention est justifiée économiquement. Il prend en compte les dégâts potentiels et le coût des traitements.\n\nDes observations régulières au champ et des pièges permettent d'estimer la population. Les seuils varient selon la culture, le stade et le contexte économique.\n\nEn lutte intégrée, respecter les niveaux seuils évite des traitements inutiles et conserve les auxiliaires. Des outils d’aide à la décision intègrent ces valeurs."
-  },
-  {
-    "date": "2024-12-29",
-    "target": "Piétin-verse",
-    "text": "Le piétin-verse est une maladie fongique des céréales causée par Gaeumannomyces graminis, provoquant des lésions sur les racines et la base des tiges. Il entraîne des verse et des pertes de rendement.\n\nLe champignon survit dans les résidus et le sol, colonisant les racines au printemps. Les symptômes incluent un blanchiment des épis et des taches nécrotiques sur la gaine.\n\nLa gestion repose sur la rotation, l'utilisation de variétés tolérantes et des traitements de semences. Une fertilisation équilibrée limite la sensibilité."
-  },
-  {
-    "date": "2024-12-30",
-    "target": "Mildiou de la vigne",
-    "text": "Le mildiou de la vigne, causé par Plasmopara viticola, attaque les feuilles, grappes et rameaux sous climat humide. Il se manifeste par des taches huileuses et un feutrage blanc au revers des feuilles.\n\nLe cycle comprend des contaminations primaires à partir des oospores du sol puis des contaminations secondaires via les spores. Les périodes pluvieuses prolongées favorisent l'épidémie.\n\nLa lutte combine la surveillance, les prévisions météo, la gestion du feuillage et les traitements fongicides. Des cépages résistants complètent la stratégie."
-  },
-  {
-    "date": "2024-12-31",
-    "target": "Oïdium du blé",
-    "text": "L’oïdium du blé est une maladie due à Blumeria graminis f.sp. tritici, formant un feutrage blanc sur les feuilles et les gaines. Il réduit la surface photosynthétique.\n\nLe champignon se propage par le vent et peut hiverner sur les résidus. Les symptômes apparaissent dès les stades jeunes par temps doux et humide.\n\nLa gestion passe par le choix variétal, la fertilisation équilibrée et des traitements ciblés lorsque le seuil est dépassé. Les pratiques culturales réduisant l'humidité foliaire limitent les attaques."
-  },
-  {
-    "date": "2025-01-01",
-    "target": "Rouille jaune",
-    "text": "La rouille jaune du blé, causée par Puccinia striiformis, se manifeste par des pustules orangées alignées sur les feuilles. Elle se développe par temps frais et humide.\n\nLe champignon produit des spores très contagieuses transportées par le vent. Les attaques précoces entraînent une forte perte de rendement.\n\nDes variétés résistantes, des semis adaptés et un suivi des bulletins d'alerte permettent de contenir la rouille jaune. Des fongicides peuvent être nécessaires en cas de forte pression."
-  },
-  {
-    "date": "2025-01-02",
-    "target": "Rouille brune",
-    "text": "La rouille brune du blé, due à Puccinia triticina, provoque des pustules brun-orangé dispersées sur le feuillage. Elle apparaît plutôt en fin de cycle par temps chaud.\n\nLes spores germent sur les feuilles humides et infectent rapidement les tissus. Des cycles successifs augmentent la pression en conditions favorables.\n\nLa lutte repose sur le choix variétal, la rotation et la surveillance. Des traitements curatifs peuvent être déclenchés au-delà des seuils recommandés."
-  },
-  {
-    "date": "2025-01-03",
-    "target": "Fusariose",
-    "text": "Les fusarioses des céréales, causées par des Fusarium spp., entraînent des échaudages, des mycotoxines et des pertes de qualité. Elles infectent l'épi au moment de la floraison.\n\nLes spores proviennent des résidus de culture et des sols. Les conditions chaudes et humides durant la floraison favorisent l'infection.\n\nLes leviers incluent la gestion des résidus, le choix variétal, l'évitement des stress et des traitements fongicides ciblés. Des analyses surveillent les mycotoxines dans les grains récoltés."
-  },
-  {
-    "date": "2025-01-04",
+    "date": "2025-10-07",
     "target": "Phytophthora infestans",
     "text": "Phytophthora infestans est l'agent du mildiou de la pomme de terre et de la tomate, provoquant des taches brun-olive et des pourritures. Il peut détruire une culture en quelques jours.\n\nLe pathogène se propage par des spores nageuses et des sporanges transportés par le vent ou les éclaboussures. Les températures fraîches et l'humidité élevée déclenchent les flambées.\n\nLa lutte combine rotations, destruction des fanes, surveillance météo et applications fongicides préventives. Des variétés tolérantes et des systèmes d'alerte complètent la protection."
   },
   {
-    "date": "2025-01-05",
-    "target": "Nématode à kystes",
-    "text": "Les nématodes à kystes (Globodera spp., Heterodera spp.) parasitent les racines de cultures comme la pomme de terre ou la betterave. Ils forment des kystes remplis d'œufs qui survivent plusieurs années.\n\nLes infestations entraînent un nanisme, une chlorose et une réduction du rendement. Les kystes se disséminent via le sol et le matériel agricole.\n\nLa gestion s'appuie sur des rotations longues, des variétés résistantes, des plantes pièges et l'hygiène du matériel. Des analyses de sol détectent leur présence."
+    "date": "2025-10-08",
+    "target": "Engrais vert",
+    "text": "Les engrais verts sont des cultures temporaires destinées à être enfouies ou roulées pour enrichir le sol en matière organique et nutriments. Ils structurent également les profils.\n\nLes légumineuses fixent l'azote, tandis que les crucifères mobilisent des éléments comme le phosphore ou les nématicides naturels. Leur système racinaire améliore la porosité.\n\nEn rotation, les engrais verts réduisent les adventices, limitent l'érosion et apportent des bénéfices agronomiques durables. Leur choix se fait selon le climat, le type de sol et la culture suivante."
   },
   {
-    "date": "2025-01-06",
-    "target": "Aleurode",
-    "text": "Les aleurodes, ou mouches blanches, sucent la sève des cultures sous serre ou de plein champ, transmettent des virus et sécrètent du miellat. Elles prolifèrent par temps chaud et sec.\n\nLeur cycle rapide et la présence de nombreux biotypes compliquent la lutte. Les larves se fixent sur la face inférieure des feuilles, protégées par une cuticule cireuse.\n\nLes stratégies incluent la lutte biologique avec des parasitoïdes, les filets anti-insectes, les panneaux chromatiques et des traitements ciblés. La rotation des modes d'action évite les résistances."
-  },
-  {
-    "date": "2025-01-07",
-    "target": "Puceron vert du pêcher",
-    "text": "Le puceron vert du pêcher (Myzus persicae) est un ravageur polyphage qui colonise de nombreuses cultures et transmet des virus. Il forme des colonies sur les jeunes pousses.\n\nSa reproduction parthénogénétique permet des explosions de population rapides. Il se déplace entre plantes hôtes primaires et secondaires au fil des saisons.\n\nLa lutte repose sur la surveillance, l'installation de plantes pièges, la conservation des auxiliaires et, si nécessaire, des traitements raisonnées. Des variétés résistantes aux virus limitent les conséquences."
-  },
-  {
-    "date": "2025-01-08",
-    "target": "Cicadelle de la flavescence",
-    "text": "La cicadelle Scaphoideus titanus transmet la flavescence dorée de la vigne, une maladie à phytoplasme. Elle se nourrit sur les feuilles et injecte l'agent pathogène.\n\nLes larves se développent sur les bois de vigne et nécessitent des températures estivales pour compléter leur cycle. Les symptômes apparaissent l'année suivante avec un jaunissement et un flétrissement des grappes.\n\nLa lutte combine la surveillance, l'arrachage des ceps contaminés, des insecticides ciblés et la gestion des repousses. Des filets anti-insectes et des cépages tolérants sont à l'étude."
-  },
-  {
-    "date": "2025-01-09",
-    "target": "Charançon de la betterave",
-    "text": "Le charançon de la betterave (Lixus junci) pond dans les pétioles, provoquant des galeries et des flétrissements. Les larves se développent à l'intérieur des tissus.\n\nLes adultes émergent au printemps et se nourrissent des feuilles. Les dégâts entraînent des pertes de surface foliaire et une baisse de rendement.\n\nLa surveillance des vols, le binage et des traitements ciblés au seuil permettent de limiter l'infestation. Des rotations réduisent les populations en privant les larves de leur hôte."
-  },
-  {
-    "date": "2025-01-10",
+    "date": "2025-10-09",
     "target": "Mineuse de la tomate",
     "text": "La mineuse de la tomate (Tuta absoluta) creuse des galeries dans les feuilles, tiges et fruits. Elle cause des pertes importantes en culture sous abri et plein champ.\n\nLes larves se développent à l'intérieur des tissus, rendant les traitements de contact peu efficaces. Plusieurs générations se succèdent rapidement.\n\nLa lutte comprend des pièges à phéromones, des filets, la lutte biologique avec des parasitoïdes, et des traitements ciblés. Une hygiène rigoureuse des serres limite les résurgences."
   },
   {
-    "date": "2025-01-11",
+    "date": "2025-10-10",
+    "target": "Irrigation gravitaire",
+    "text": "L'irrigation gravitaire repose sur l'écoulement de l'eau par gravité dans des planches ou des sillons. Elle reste largement utilisée dans les régions disposant de ressources abondantes.\n\nLa maîtrise du nivellement, de la vitesse d'avancée et des volumes conditionne son efficacité. Des pertes par infiltration profonde ou ruissellement peuvent survenir.\n\nEn grande culture ou en riziculture, l'irrigation gravitaire reste économique mais demande une gestion précise pour limiter les gaspillages. Des aménagements de parcelles améliorent sa performance."
+  },
+  {
+    "date": "2025-10-11",
+    "target": "Tassement du sol",
+    "text": "Le tassement du sol résulte du passage répété d'engins ou de la pluie sur des sols nus, réduisant la porosité macro. Il freine l'enracinement et l'infiltration.\n\nLes horizons compactés présentent une densité apparente élevée et des fissures verticales limitées. La pénétration racinaire se concentre alors dans des galeries préexistantes.\n\nEn agronomie, prévenir le tassement passe par la limitation des charges à l'essieu, l'utilisation de pneus larges, le respect du ressuyage et la couverture permanente. Des diagnostics de résistance à la pénétration orientent les décisions."
+  },
+  {
+    "date": "2025-10-12",
+    "target": "Coiffe racinaire",
+    "text": "La coiffe racinaire protège le méristème apical en amortissant les frottements contre les particules du sol. Elle oriente aussi la croissance en percevant la gravité et en modulant la distribution des auxines.\n\nSes cellules mucilagineuses se renouvellent constamment et libèrent des polysaccharides qui facilitent la pénétration. Des statolithes internes renseignent la plante sur la direction à prendre pour maintenir une croissance verticale.\n\nEn agronomie, préserver la coiffe racinaire implique d'éviter les compactages sévères et les sols saturés en eau qui pourraient l'asphyxier. Des semis trop profonds ou des sols croûtés freinent son action protectrice et la vigueur des plantules."
+  },
+  {
+    "date": "2025-10-13",
+    "target": "Cambium",
+    "text": "Le cambium constitue une fine assise méristématique responsable de la croissance en diamètre des tiges et des racines. Il réactive chaque saison ses divisions pour former de nouveaux anneaux conducteurs, modulant le rapport entre xylème et phloème selon les besoins de la plante.\n\nEn coupe transversale, on distingue ses cellules fusiformes à paroi fine capables de se dédifférencier et de redonner des tissus spécialisés. Les gradients hormonaux latéraux guident l'orientation des divisions et favorisent une alternance régulière des files conductrices.\n\nEn arboriculture, la maîtrise des tailles, des greffes et de la nutrition dépend de la vitalité du cambium. Des stress mécaniques ou hydriques mal gérés peuvent interrompre ses activités et compromettre la cicatrisation des plaies ou la reprise des greffons."
+  },
+  {
+    "date": "2025-10-14",
+    "target": "Bois initial",
+    "text": "Le bois initial correspond aux premières cellules ligneuses produites au printemps, larges et à parois fines, favorisant la conduction rapide de la sève. Il contraste avec le bois d'été plus dense.\n\nLes vaisseaux y sont nombreux et de grand diamètre, ce qui rend la zone plus vulnérable aux embolies. Les anneaux de bois reflètent ainsi les conditions climatiques de croissance.\n\nEn foresterie et arboriculture, l'analyse du bois initial aide à comprendre la vigueur et l'historique hydrique des arbres. Des stress printaniers peuvent réduire sa formation et impacter la croissance annuelle."
+  },
+  {
+    "date": "2025-10-15",
+    "target": "Germination",
+    "text": "La germination débute lorsque la graine absorbe l'eau et réactive son métabolisme, entraînant l'allongement de la radicule. La mobilisation des réserves nourrit les premiers stades jusqu'à l'autonomie photosynthétique.\n\nLes enzymes hydrolytiques libèrent les sucres, acides aminés et lipides stockés dans l'endosperme ou les cotylédons. La température, l'oxygène et l'humidité conditionnent la vitesse de ce processus.\n\nPour les agriculteurs, maîtriser la germination implique de soigner la qualité des semences, la préparation du lit de semis et la gestion de l'humidité. Des tests de pouvoir germinatif orientent les densités de semis."
+  },
+  {
+    "date": "2025-10-16",
+    "target": "Compostage",
+    "text": "Le compostage transforme les résidus organiques en un amendement stable riche en humus. Il s'effectue par une décomposition aérobie contrôlée.\n\nLa maîtrise du rapport carbone/azote, de l'humidité et de l'aération assure une montée en température suffisante pour hygiéniser le compost. Les retournements homogénéisent le processus.\n\nPour les exploitations, le compostage valorise les déchets organiques, réduit les achats d'engrais et améliore la structure du sol. Des analyses garantissent la qualité du produit fini."
+  },
+  {
+    "date": "2025-10-17",
+    "target": "Brumisation",
+    "text": "La brumisation diffuse de fines gouttelettes d'eau pour maintenir une humidité élevée autour des plantes sans détremper le substrat. Elle limite les stress hydriques et thermiques.\n\nDes buses spécifiques et des programmateurs régulent la fréquence et la durée des cycles. L'eau doit être filtrée pour éviter l'encrassement et les dépôts.\n\nEn pépinière, en serre ou en salle de culture, la brumisation améliore la reprise des boutures, la germination et le confort des plants. Elle s'intègre au pilotage climatique."
+  },
+  {
+    "date": "2025-10-18",
+    "target": "Bande enherbée",
+    "text": "La bande enherbée est une zone permanente de graminées ou légumineuses laissée en bordure ou au cœur des parcelles. Elle intercepte les ruissellements et fournit un habitat aux auxiliaires.\n\nSa structure dense ralentit l'eau et piége les sédiments. Elle se fauche généralement une à deux fois par an pour maintenir sa fonction.\n\nDans les systèmes agricoles, les bandes enherbées s'intègrent aux dispositifs d'infrastructures agroécologiques. Elles participent à la conformité environnementale et à la lutte contre l'érosion."
+  },
+  {
+    "date": "2025-10-19",
+    "target": "Paroi secondaire",
+    "text": "La paroi secondaire se dépose après la croissance, renforçant la cellule par des couches riches en cellulose et lignine. Elle confère une rigidité importante.\n\nLes trois couches S1, S2 et S3 présentent des orientations différentes de microfibrilles, optimisant la résistance mécanique. Des dépôts de lignine complètent la structure.\n\nPour les usages industriels du bois et des fibres, la qualité de la paroi secondaire détermine la solidité et la densité du matériau. Les conditions de croissance et les variétés influencent ces paramètres."
+  },
+  {
+    "date": "2025-10-20",
+    "target": "Plante compagne",
+    "text": "Une plante compagne est associée à la culture principale pour apporter un service : soutien physique, attraction des pollinisateurs ou contrôle des ravageurs. Elle est semée simultanément ou peu après.\n\nElle peut servir de tuteur vivant, libérer des composés bénéfiques ou couvrir le sol pour limiter les adventices. Sa densité et sa conduite sont ajustées pour éviter la concurrence.\n\nEn maraîchage et en grandes cultures, les plantes compagnes améliorent la résilience et l'efficience des systèmes. Des expérimentations locales déterminent les meilleures associations."
+  },
+  {
+    "date": "2025-10-21",
+    "target": "Lumière artificielle horticole",
+    "text": "L'éclairage horticole artificiel fournit une lumière adaptée à la photosynthèse lorsque l'éclairement naturel est insuffisant. Les technologies LED permettent de moduler le spectre et l'intensité.\n\nLes plantes répondent différemment aux longueurs d'onde bleu, rouge ou far-red. Des programmes lumineux ajustés soutiennent la croissance, la floraison ou la fructification.\n\nEn cultures indoor ou sous serre, la lumière artificielle prolonge les photopériodes, assure une production hivernale et améliore la qualité des plantes. Elle s'inscrit dans un pilotage énergétique précis."
+  },
+  {
+    "date": "2025-10-22",
+    "target": "Phytochrome",
+    "text": "Le phytochrome est un photorécepteur qui perçoit la lumière rouge et rouge lointain, régulant la germination, la floraison et la croissance. Il bascule entre deux formes selon la longueur d'onde reçue.\n\nCette protéine s'accumule dans le cytoplasme et le noyau, où elle interagit avec des facteurs de transcription pour moduler l'expression génique. Les rythmes circadiens en dépendent largement.\n\nEn horticulture, la manipulation du phytochrome via des éclairages spécifiques permet de contrôler la floraison ou l'allongement des tiges. Des écrans d'ombrage ou des LEDs adaptées sont utilisés."
+  },
+  {
+    "date": "2025-10-23",
+    "target": "Prairie temporaire",
+    "text": "La prairie temporaire est implantée pour quelques années dans une rotation, apportant fourrage et améliorant le sol. Elle associe souvent graminées et légumineuses.\n\nSes racines densifient les horizons et fixent l'azote, tandis que la couverture limite l'érosion. Après retournement, elle laisse un sol structuré pour la culture suivante.\n\nPour les éleveurs et céréaliers, la prairie temporaire rétablit la fertilité et brise les cycles des adventices. Une gestion du pâturage et des coupes optimise sa valeur fourragère."
+  },
+  {
+    "date": "2025-10-24",
+    "target": "Potentiel hydrique",
+    "text": "Le potentiel hydrique exprime l'énergie libre de l'eau dans un système, conditionnant les flux entre sol, plante et atmosphère. Les gradients orientent la circulation de l'eau depuis les zones humides vers les zones plus sèches.\n\nDans la plante, il résulte de la combinaison des potentiels osmotiques, matriciels et de pression. Les cellules ajustent leur turgescence en modulant les solutés internes pour maintenir un gradient favorable.\n\nEn agronomie, mesurer le potentiel hydrique des feuilles ou du sol aide à décider des irrigations et à anticiper les stress. Des outils comme la chambre à pression ou les sondes tensiométriques fournissent ces indicateurs."
+  },
+  {
+    "date": "2025-10-25",
+    "target": "Méristème apical",
+    "text": "Le méristème apical des tiges pilote l'allongement et l'organisation des organes aériens, depuis les feuilles jusqu'aux fleurs. Sa zone centrale conserve des cellules indifférenciées, tandis que ses zones périphériques fournissent rapidement des cellules spécialisées.\n\nAu microscope, la distinction entre tunica et corpus révèle des divisions orientées qui déterminent la phyllotaxie et l'architecture de la plante. Les signaux hormonaux comme les auxines concentrées au sommet orchestrent ces dynamiques et assurent la dominance apicale.\n\nEn production légumière ou fruitière, la gestion des pincements, de l'ébourgeonnage ou de l'ébourgeonnement vise à moduler l'activité du méristème apical. Comprendre son fonctionnement aide à équilibrer végétation et fructification selon les objectifs de rendement."
+  },
+  {
+    "date": "2025-10-26",
+    "target": "Association maïs-haricot",
+    "text": "L'association maïs-haricot combine une céréale haute servant de tuteur et une légumineuse grimpante fixant l'azote. Elle s'inspire des systèmes traditionnels d'agriculture associée.\n\nLe maïs offre un support pour le haricot, tandis que ce dernier enrichit le sol en azote et diversifie la production. Les dates de semis doivent être coordonnées pour éviter la concurrence précoce.\n\nPour les agriculteurs en agroécologie, cette association augmente la résilience, favorise la couverture du sol et offre des récoltes complémentaires. Elle requiert une gestion attentive des densités et de la récolte."
+  },
+  {
+    "date": "2025-10-27",
+    "target": "Symbiose mycorhizienne",
+    "text": "La symbiose mycorhizienne associe les racines des plantes et des champignons qui étendent la zone d'exploration du sol. Les hyphes apportent des nutriments peu mobiles, notamment le phosphore, en échange de sucres.\n\nOn distingue des mycorhizes arbusculaires et ectomycorhiziennes, chacune présentant des structures d'échange caractéristiques comme les arbuscules ou les manchons fongiques. Ces interfaces optimisent les transferts et protègent la racine des pathogènes.\n\nEn agriculture, favoriser la symbiose mycorhizienne passe par une réduction du travail du sol, des rotations diversifiées et l'utilisation raisonnée de fongicides. Des inoculums peuvent être appliqués lors du semis pour accélérer la colonisation."
+  },
+  {
+    "date": "2025-10-28",
+    "target": "Gravitropisme",
+    "text": "Le gravitropisme oriente les racines vers le bas et les tiges vers le haut en réponse à la gravité. Des statolithes, amyloplastes denses, sédimentent dans des cellules spécialisées pour indiquer la direction.\n\nLes gradients d'auxine induits par ce signal modifient l'élongation cellulaire différemment dans les racines et les tiges. Un repositionnement rapide assure le maintien de la posture.\n\nEn agronomie, comprendre le gravitropisme aide à manipuler les semences, les boutures et les plants lors du repiquage. Des inversions prolongées peuvent perturber la croissance et réduire la vigueur."
+  },
+  {
+    "date": "2025-10-29",
+    "target": "Haie brise-vent",
+    "text": "La haie brise-vent protège les cultures et les élevages des vents dominants, réduisant l'évaporation et les dégâts mécaniques. Elle sert aussi d'abri à la faune auxiliaire.\n\nComposée d'espèces variées, elle étale la floraison et la fructification tout en offrant des strates de hauteur différentes. Son entretien inclut la taille et le renouvellement des plants.\n\nEn agriculture, une haie brise-vent bien placée améliore les microclimats, limite la dérive des produits phytosanitaires et stocke du carbone. Des dispositifs agro-environnementaux encouragent son implantation."
+  },
+  {
+    "date": "2025-10-30",
+    "target": "Fusariose",
+    "text": "Les fusarioses des céréales, causées par des Fusarium spp., entraînent des échaudages, des mycotoxines et des pertes de qualité. Elles infectent l'épi au moment de la floraison.\n\nLes spores proviennent des résidus de culture et des sols. Les conditions chaudes et humides durant la floraison favorisent l'infection.\n\nLes leviers incluent la gestion des résidus, le choix variétal, l'évitement des stress et des traitements fongicides ciblés. Des analyses surveillent les mycotoxines dans les grains récoltés."
+  },
+  {
+    "date": "2025-10-31",
+    "target": "Culture hydroponique",
+    "text": "La culture hydroponique cultive les plantes hors sol dans une solution nutritive contrôlée. Les racines sont suspendues ou supportées dans un substrat neutre.\n\nLa composition de la solution, le pH, l'oxygénation et la température doivent être surveillés en continu. Les systèmes peuvent être en flux continu, NFT ou en goutte-à-goutte.\n\nPour les serristes, l'hydroponie offre des rendements élevés, une maîtrise sanitaire et une consommation d'eau réduite. Elle nécessite un investissement technologique et une expertise technique."
+  },
+  {
+    "date": "2025-11-01",
+    "target": "Cytokinine",
+    "text": "Les cytokinines stimulent la division cellulaire et retardent la sénescence des feuilles. Elles sont produites dans les racines et transportées vers les organes aériens.\n\nAu niveau moléculaire, elles activent des cascades de phosphorylation qui régulent l'expression de gènes liés au cycle cellulaire. Elles agissent souvent en interaction avec les auxines.\n\nPour les producteurs, l'application de cytokinines en foliaire peut maintenir la verdure et favoriser le remplissage des fruits. Elles interviennent aussi dans les protocoles de culture in vitro pour initier les bourgeons."
+  },
+  {
+    "date": "2025-11-02",
+    "target": "Irrigation goutte-à-goutte",
+    "text": "L'irrigation goutte-à-goutte apporte l'eau au plus près des racines via des émetteurs localisés, limitant les pertes par évaporation. Elle permet de piloter finement les doses.\n\nLes débits se règlent en fonction du stade de la culture, de la texture du sol et du climat. Les réseaux nécessitent un filtrage et un entretien réguliers pour éviter l'obstruction des goutteurs.\n\nEn arboriculture, maraîchage ou horticulture, cette technique améliore l'efficience hydrique et permet la fertigation. Des sondes et des bilans hydriques assistent le pilotage."
+  },
+  {
+    "date": "2025-11-03",
+    "target": "Parenchyme palissadique",
+    "text": "Le parenchyme palissadique constitue la principale zone photosynthétique des feuilles, grâce à ses cellules allongées riches en chloroplastes. Son organisation compacte maximise la capture de lumière avant que les photons ne se dispersent dans les tissus plus lâches.\n\nLes chloroplastes s'y réarrangent selon l'intensité lumineuse, se plaçant sur les parois latérales en cas de forte lumière pour éviter la photoinhibition. Les mouvements cytoplasmiques assurent une distribution homogène des ressources produites vers les autres tissus.\n\nChez les espèces cultivées, l'épaisseur du parenchyme palissadique varie selon les conditions de culture et le niveau d'ombre. Les pratiques de densité de semis ou de conduite de la canopée influencent donc la performance photosynthétique et le rendement."
+  },
+  {
+    "date": "2025-11-04",
     "target": "Tuta absoluta",
     "text": "Tuta absoluta désigne l'espèce de mineuse de la tomate décrite ci-dessus, originaire d'Amérique du Sud. Elle s'est répandue en Europe et en Afrique du Nord.\n\nSon adaptation rapide et sa résistance aux insecticides compliquent la gestion. Les populations peuvent se multiplier même à faibles densités.\n\nLes stratégies combinent piégeage, auxiliaires, confusion sexuelle et rotation des produits phytosanitaires. La détection précoce est essentielle pour limiter les dégâts."
   },
   {
-    "date": "2025-01-12",
+    "date": "2025-11-05",
+    "target": "Respiration mitochondriale",
+    "text": "La respiration mitochondriale libère l'énergie des sucres produits par la photosynthèse, fournissant l'ATP nécessaire aux processus métaboliques. Elle se déroule dans la matrice et les crêtes des mitochondries.\n\nLes complexes de la chaîne respiratoire transfèrent les électrons vers l'oxygène en pompant des protons, générant un gradient utilisé par l'ATP synthase. Des voies alternatives permettent de dissiper l'excès d'énergie.\n\nDans les cultures, la respiration nocturne consomme une part du carbone accumulé le jour. Les stress thermiques ou hydriques modifient ce bilan, ce qui incite à ajuster les pratiques de récolte ou de stockage."
+  },
+  {
+    "date": "2025-11-06",
+    "target": "Travail réduit",
+    "text": "Le travail réduit limite les passages d'outils et maintient une partie des résidus en surface. Il préserve la structure du sol et réduit la consommation de carburant.\n\nLes outils utilisés sont peu agressifs, comme les déchaumeurs à dents ou les strip-till qui ne perturbent que la ligne de semis. Les rotations doivent intégrer des cultures capables de gérer les résidus.\n\nPour les agriculteurs, le travail réduit s'accompagne d'une surveillance accrue des adventices et des ravageurs. Il constitue une étape vers l'agriculture de conservation."
+  },
+  {
+    "date": "2025-11-07",
+    "target": "Rhizoderme",
+    "text": "Le rhizoderme constitue l'épiderme des racines jeunes, interface directe entre la plante et la solution du sol. Ses cellules fines laissent passer l'eau et les ions avant que les tissus ne se subérifient plus tardivement.\n\nIl est le siège de la formation des poils absorbants, prolongeant la surface d'échange et hébergeant fréquemment des micro-organismes bénéfiques. Les exsudats libérés par ces cellules influencent la rhizosphère.\n\nDans les contextes agricoles, un rhizoderme fonctionnel dépend d'un bon état sanitaire du sol, de l'absence de toxicité et d'une humidité suffisante. Les stress chimiques ou salins peuvent rapidement le dégrader et limiter l'absorption."
+  },
+  {
+    "date": "2025-11-08",
+    "target": "Photorespiration",
+    "text": "La photorespiration survient lorsque la Rubisco fixe l'oxygène au lieu du CO₂, entraînant une perte d'énergie et de carbone. Ce phénomène s'accentue à forte température ou faible CO₂.\n\nElle implique un métabolisme complexe entre chloroplastes, peroxysomes et mitochondries pour recycler le phosphoglycolate. Malgré son coût, elle protège la cellule contre les excès d'énergie lumineuse.\n\nEn agronomie, limiter la photorespiration passe par le choix de variétés tolérantes, la gestion de l'ombrage et l'équilibre hydrique. Certaines pratiques de fertilisation azotée soutiennent la synthèse d'enzymes clés pour compenser ces pertes."
+  },
+  {
+    "date": "2025-11-09",
+    "target": "Capteur d’éclairement",
+    "text": "Les capteurs d'éclairement mesurent l'intensité lumineuse reçue par la culture, en lux ou en µmol·m⁻²·s⁻¹. Ils évaluent l'efficacité de l'éclairage naturel ou artificiel.\n\nDes capteurs quantiques ou photométriques sont installés à hauteur de canopée pour suivre les variations journalières. Les données guident les ajustements d'ombrage ou d'éclairage.\n\nDans les serres et les cultures indoor, ces capteurs optimisent la photosynthèse tout en limitant la consommation énergétique. Ils s'intègrent aux systèmes de pilotage climatique."
+  },
+  {
+    "date": "2025-11-10",
+    "target": "Lignine",
+    "text": "La lignine rigidifie les parois secondaires des cellules, conférant résistance mécanique et imperméabilité. Elle s'accumule dans le xylème, les fibres et certains tissus de soutien.\n\nSa polymérisation résulte de la déhydrogénation de monolignols et se dépose entre les microfibrilles de cellulose. Elle limite la digestibilité des tissus par les herbivores et les micro-organismes.\n\nEn industrie et en agriculture, la lignine influence la qualité des fourrages, la transformation des fibres et la résistance des cultures aux pathogènes. Des variétés à lignification modifiée sont recherchées pour divers usages."
+  },
+  {
+    "date": "2025-11-11",
+    "target": "Osmorégulation",
+    "text": "L'osmorégulation correspond à la capacité des cellules à ajuster leur concentration interne en solutés pour maintenir la turgescence. Elle intervient face aux variations d'humidité ou de salinité.\n\nLes plantes accumulent des osmoprotecteurs comme les prolines ou les sucres solubles qui stabilisent les structures cellulaires. Les aquaporines modulent aussi les flux d'eau pour équilibrer les pressions.\n\nPour les cultures, soutenir l'osmorégulation implique une nutrition équilibrée et des stratégies anti-stress comme les biostimulants. Les variétés tolérantes sont sélectionnées pour leur capacité à maintenir ce contrôle."
+  },
+  {
+    "date": "2025-11-12",
     "target": "Bactérie Xylella fastidiosa",
     "text": "Xylella fastidiosa est une bactérie xylémique qui obstrue les vaisseaux des plantes hôtes, provoquant des dépérissements. Elle touche de nombreuses espèces, dont l'olivier.\n\nTransmise par des insectes vecteurs comme les cicadelles, elle se multiplie dans le xylème et bloque la circulation de la sève. Les symptômes incluent des brûlures foliaires et un dessèchement progressif.\n\nLa gestion repose sur la surveillance, l'arrachage des plantes atteintes, la limitation des vecteurs et la diversification variétale. Des recherches visent à identifier des porte-greffes tolérants."
   },
   {
-    "date": "2025-01-13",
+    "date": "2025-11-13",
+    "target": "Transpiration foliaire",
+    "text": "La transpiration foliaire représente l'essentiel des pertes d'eau de la plante, assurant aussi le refroidissement et le transport des nutriments. Son intensité dépend de la lumière, de la température et du déficit de saturation de l'air.\n\nAu niveau des stomates, l'ouverture régule les flux, tandis que la cuticule contribue à une transpiration résiduelle. Les gradients de vapeur se déplacent à travers le parenchyme spongieux avant de quitter la feuille.\n\nPour les agriculteurs, suivre la transpiration aide à piloter l'irrigation et à dimensionner les serres ou filets d'ombrage. Des stress hydriques prolongés ferment les stomates et impactent directement la photosynthèse."
+  },
+  {
+    "date": "2025-11-14",
+    "target": "Sélection participative",
+    "text": "La sélection participative associe agriculteurs, techniciens et chercheurs pour co-sélectionner des variétés répondant aux besoins locaux. Elle valorise les savoirs empiriques.\n\nLes essais sont conduits directement sur les exploitations, avec une observation fine des comportements en conditions réelles. Les critères incluent la résilience, le goût et la facilité de conduite.\n\nCette approche favorise l'adoption des innovations, la diversité génétique et l'autonomie semencière. Elle crée un lien étroit entre recherche et terrain."
+  },
+  {
+    "date": "2025-11-15",
+    "target": "Calage variétal",
+    "text": "Le calage variétal consiste à choisir les variétés adaptées au terroir, aux contraintes climatiques et au marché. Il prend en compte les cycles, les résistances et la qualité.\n\nDes essais comparatifs, des réseaux d'expérimentation et des retours de terrain alimentent le choix. Les caractéristiques recherchées évoluent avec les attentes des filières.\n\nPour les agriculteurs, un calage variétal pertinent sécurise le rendement, la précocité et la valorisation commerciale. Il s'actualise régulièrement face aux nouveaux cultivars."
+  },
+  {
+    "date": "2025-11-16",
+    "target": "Transport actif",
+    "text": "Le transport actif déplace des solutés contre leur gradient de concentration en utilisant de l'énergie, souvent sous forme d'ATP. Il garantit la nutrition minérale même lorsque les concentrations externes sont faibles.\n\nDes pompes H⁺-ATPases établissent un gradient électrochimique qui alimente des symporteurs ou antiporteurs spécifiques. Ce mécanisme se retrouve dans les racines comme dans les feuilles.\n\nEn agronomie, la compréhension du transport actif permet d'optimiser les formulations d'engrais et les apports foliaires. Des applications trop concentrées peuvent saturer ces systèmes et provoquer des brûlures."
+  },
+  {
+    "date": "2025-11-17",
+    "target": "Racine pivotante",
+    "text": "La racine pivotante explore en profondeur les horizons du sol, ancrant solidement la plante et accédant à des réserves d'eau éloignées de la surface. Elle domine souvent les racines latérales lors des premiers stades de développement.\n\nEn coupe, elle montre un cylindre central robuste entouré d'un cortex épais capable de stocker des réserves. Les différences de densité entre tissus témoignent de la transition progressive vers un fonctionnement plus ligneux.\n\nDans les systèmes de grandes cultures ou de luzerne, préserver un sol meuble en profondeur et éviter les semelles de labour assure l'efficacité de la racine pivotante. Cela conditionne la résilience face aux sécheresses estivales."
+  },
+  {
+    "date": "2025-11-18",
+    "target": "Amendement calcaire",
+    "text": "L'amendement calcaire élève le pH des sols acides et apporte du calcium. Il favorise la structure et l'activité biologique.\n\nDifférentes formes existent, de la craie aux carbonates broyés, avec des vitesses de réaction variables. Les doses se calculent selon la capacité tampon et la culture.\n\nEn agriculture, un amendement calcaire régulier évite les blocages de phosphore et améliore l'efficacité des engrais. Il se combine à des analyses de sol pour ajuster les apports."
+  },
+  {
+    "date": "2025-11-19",
+    "target": "Système riz-poisson",
+    "text": "Le système riz-poisson associe la riziculture et l'élevage de poissons dans les mêmes parcelles inondées. Les poissons valorisent les ressources aquatiques et contrôlent certains ravageurs.\n\nLeurs mouvements aèrent l'eau, recyclent les résidus et apportent des nutriments via leurs déjections. Le riz bénéficie d'une fertilisation naturelle et d'une réduction des larves d'insectes.\n\nPour les producteurs, ce système diversifie les revenus et améliore l'efficience de l'eau. Il demande une conception adaptée des parcelles et un suivi sanitaire des poissons."
+  },
+  {
+    "date": "2025-11-20",
+    "target": "Signal calcique",
+    "text": "Le signal calcique agit comme second messager universel dans les cellules végétales, traduisant les stimulations en réponses adaptées. Des variations de concentration cytosolique déclenchent des cascades de phosphorylation.\n\nDes canaux membranaires spécialisés contrôlent les entrées et sorties de calcium, tandis que des pompes et échangeurs rétablissent l'homéostasie. Les organites comme le réticulum ou la vacuole servent de réservoirs.\n\nEn physiologie végétale appliquée, comprendre le signal calcique permet d'améliorer la tolérance aux stress et d'ajuster des pulvérisations foliaires en calcium. Des outils de biologie moléculaire mesurent ces flux en temps réel."
+  },
+  {
+    "date": "2025-11-21",
+    "target": "Agroforesterie",
+    "text": "L'agroforesterie associe arbres et cultures ou animaux sur une même parcelle, créant des interactions positives. Les arbres fournissent ombre, abris et services écosystémiques.\n\nLeur système racinaire explore des horizons complémentaires tandis que la litière enrichit le sol. Les haies ou alignements influencent le microclimat et la biodiversité.\n\nPour les exploitations, l'agroforesterie diversifie les productions, valorise les surfaces et renforce la résilience. Elle nécessite une planification soignée de l'espacement et des espèces."
+  },
+  {
+    "date": "2025-11-22",
+    "target": "Piégeage massif",
+    "text": "Le piégeage massif vise à capturer un grand nombre d'individus d'un ravageur pour réduire sa pression. Il utilise des appâts alimentaires, visuels ou phéromonaux.\n\nLes pièges doivent être disposés en nombre suffisant et entretenus régulièrement. Leur efficacité dépend de la période d'installation et de la densité de la population cible.\n\nDans les cultures maraîchères ou arboricoles, le piégeage massif complète la lutte biologique et chimique. Il permet de diminuer les seuils d'infestation avant l'apparition des dégâts."
+  },
+  {
+    "date": "2025-11-23",
+    "target": "Cutine",
+    "text": "La cutine est un polyester lipidique qui forme la matrice de la cuticule, limitant les pertes d'eau et protégeant contre les agressions. Elle s'associe à des cires pour créer une barrière hydrophobe.\n\nSon assemblage dépend de la synthèse d'acides gras hydroxylés et de leur polymérisation. Les gènes impliqués répondent aux stimuli lumineux et hydriques.\n\nPour les cultures, l'état de la cutine conditionne la résistance aux maladies foliaires et l'efficacité des traitements. Des pratiques culturales équilibrées soutiennent sa formation."
+  },
+  {
+    "date": "2025-11-24",
+    "target": "Sonde capacitive",
+    "text": "La sonde capacitive mesure la teneur en eau du sol en évaluant sa permittivité diélectrique. Elle fournit des données en continu pour piloter l'irrigation.\n\nInstallée à différentes profondeurs, elle renseigne sur l'évolution de l'humidité dans le profil. Les données peuvent être transmises à distance et intégrées dans des modèles de décision.\n\nEn agriculture de précision, les sondes capacitives permettent d'ajuster les apports d'eau, d'éviter les stress hydriques et de rationaliser l'énergie consommée par les systèmes d'irrigation."
+  },
+  {
+    "date": "2025-11-25",
+    "target": "Confusion sexuelle",
+    "text": "La confusion sexuelle consiste à diffuser des phéromones pour perturber l'accouplement des ravageurs. Elle réduit les populations sans intervention directe sur les individus.\n\nDes diffuseurs placés dans la parcelle créent un nuage odorant homogène qui empêche les mâles de localiser les femelles. Les formulations doivent être renouvelées selon leur durée d'action.\n\nEn viticulture et arboriculture, cette technique cible les lépidoptères comme la tordeuse ou le carpocapse. Elle s'associe à une surveillance continue pour vérifier l'efficacité."
+  },
+  {
+    "date": "2025-11-26",
+    "target": "Planteuse",
+    "text": "La planteuse mécanise la mise en place de plants, bulbes ou tubercules en respectant l'espacement désiré. Elle réduit la pénibilité et accroît la régularité des plantations.\n\nElle comporte des godets, cupules ou plateaux qui déposent le plant dans un sillon ouvert, avant de le refermer et d'assurer le rappuyage. Certains modèles combinent fertilisation ou irrigation localisée.\n\nPour les maraîchers et producteurs de pommes de terre, une planteuse bien réglée assure une implantation homogène et réduit les manques. L'alimentation régulière des plants et la qualité du lit de plantation restent déterminantes."
+  },
+  {
+    "date": "2025-11-27",
+    "target": "Bande fleurie",
+    "text": "La bande fleurie est un aménagement permanent ou temporaire composé de plantes mellifères et nectarifères en bord de parcelle. Elle soutient les pollinisateurs et les auxiliaires.\n\nSa diversité floristique étalée dans le temps garantit un apport continu de ressources. Les structures verticales qu'elle offre servent aussi d'abris et de corridors écologiques.\n\nPour les exploitations, une bande fleurie bien gérée améliore la pollinisation, la lutte biologique et l'image environnementale. Elle peut bénéficier d'aides agroécologiques."
+  },
+  {
+    "date": "2025-11-28",
+    "target": "Amendement organique",
+    "text": "Les amendements organiques, comme les fumiers ou composts, améliorent la matière organique, la structure et la biodiversité du sol. Ils libèrent des nutriments progressivement.\n\nLeur valeur agronomique dépend du rapport C/N, du degré de maturation et de la teneur en éléments nutritifs. Des plans d'épandage garantissent une répartition homogène.\n\nPour les agriculteurs, intégrer les amendements organiques dans la fertilisation réduit la dépendance aux engrais minéraux et accroît la résilience des sols. La traçabilité est essentielle."
+  },
+  {
+    "date": "2025-11-29",
+    "target": "Dormance des graines",
+    "text": "La dormance des graines empêche la germination immédiate après maturation, assurant un étalement dans le temps favorable à la survie. Elle dépend de barrières mécaniques, chimiques ou physiologiques.\n\nDes couches tégumentaires imperméables, des inhibiteurs internes ou une immaturité embryonnaire en sont responsables. Les conditions environnementales agissent comme signaux de levée de dormance.\n\nEn production de semences, gérer la dormance est essentiel pour garantir une germination homogène. Des traitements comme la scarification, la stratification ou l'utilisation de régulateurs permettent de la lever."
+  },
+  {
+    "date": "2025-11-30",
+    "target": "Xylème",
+    "text": "Le xylème assure la montée de la sève brute depuis les racines vers les organes aériens, répondant en permanence aux variations de transpiration imposées par la météo et l'activité des feuilles. Lorsque la demande est forte, la tension exercée sur cette colonne d'eau mobilise l'élasticité des parois lignifiées et révèle les limites de la conductivité hydraulique.\n\nAu microscope, on observe une succession de vaisseaux et de trachéides au lumen élargi, consolidés par des épaississements annulaires ou spiralés qui protègent le flux contre les collapsus. Les ponctuations bordées permettent des dérivations de secours, mais restent des points de fragilité lors des épisodes d'embolie.\n\nDans les systèmes agricoles, préserver un sol structuré et limiter le tassement permet au xylème de maintenir une alimentation régulière des feuilles. Les itinéraires techniques qui favorisent un enracinement profond et une irrigation raisonnée réduisent les ruptures de colonne d'eau et sécurisent la production."
+  },
+  {
+    "date": "2025-12-01",
+    "target": "Culture sur butte",
+    "text": "La culture sur butte élève la ligne de plantation pour améliorer le drainage, la structure et le réchauffement du sol. Elle est utilisée en maraîchage ou en agroforesterie tropicale.\n\nLes buttes peuvent être permanentes ou temporaires, associées à des apports de matière organique et à des paillages. Elles favorisent l'activité biologique et la profondeur racinaire.\n\nEn zones humides ou lourdes, la culture sur butte évite l'asphyxie des racines et permet des récoltes plus précoces. Elle demande un entretien pour maintenir les formes et les chemins."
+  },
+  {
+    "date": "2025-12-02",
+    "target": "Charançon de la betterave",
+    "text": "Le charançon de la betterave (Lixus junci) pond dans les pétioles, provoquant des galeries et des flétrissements. Les larves se développent à l'intérieur des tissus.\n\nLes adultes émergent au printemps et se nourrissent des feuilles. Les dégâts entraînent des pertes de surface foliaire et une baisse de rendement.\n\nLa surveillance des vols, le binage et des traitements ciblés au seuil permettent de limiter l'infestation. Des rotations réduisent les populations en privant les larves de leur hôte."
+  },
+  {
+    "date": "2025-12-03",
+    "target": "Nodulation des légumineuses",
+    "text": "La nodulation des légumineuses permet la fixation symbiotique de l'azote atmosphérique, rendant les plantes partiellement autonomes vis-à-vis des apports minéraux. Chaque nodule héberge des bactéries spécifiques capables de réduire le diazote.\n\nLes nodules actifs présentent une zone rose riche en léghémoglobine, signe d'une oxygénation contrôlée indispensable à l'activité de la nitrogénase. Leur développement dépend d'un dialogue moléculaire précis entre plante et micro-organisme.\n\nPour les agriculteurs, réussir la nodulation nécessite d'ensemencer des souches adaptées, de limiter les apports d'azote minéral au semis et de maintenir un pH favorable. Une nodulation efficace réduit les coûts de fertilisation et améliore la fertilité du sol."
+  },
+  {
+    "date": "2025-12-04",
+    "target": "Grain de pollen",
+    "text": "Le grain de pollen transporte les gamètes mâles et déclenche la reproduction chez les plantes à fleurs. Il est protégé par une exine résistante sculptée de motifs caractéristiques.\n\nÀ maturité, il déshydrate pour faciliter la dissémination puis réhydrate sur le stigmate compatible. Il renferme une cellule végétative et une cellule générative qui donnera deux spermatozoïdes.\n\nEn production fruitière, la qualité du pollen conditionne la nouaison. Les températures extrêmes, l'humidité ou les déficiences nutritives peuvent réduire sa viabilité."
+  },
+  {
+    "date": "2025-12-05",
+    "target": "Plantes de service",
+    "text": "Les plantes de service sont implantées pour apporter un bénéfice agronomique spécifique, comme attirer des auxiliaires, repousser des ravageurs ou améliorer le sol. Elles cohabitent avec la culture.\n\nElles peuvent libérer des composés volatils répulsifs, fournir du nectar aux pollinisateurs ou couvrir le sol entre les rangs. Leur cycle est coordonné avec celui de la culture principale.\n\nEn systèmes intégrés, les plantes de service renforcent la résilience et réduisent la dépendance aux intrants. Un choix judicieux d'espèces et une gestion fine du couvert sont nécessaires."
+  },
+  {
+    "date": "2025-12-06",
+    "target": "Glycolyse végétale",
+    "text": "La glycolyse végétale dégrade le glucose en pyruvate dans le cytosol, fournissant ATP et NADH pour la respiration. Elle constitue la première étape de l'utilisation des sucres.\n\nCertains intermédiaires servent à la synthèse d'acides aminés ou de lipides, rendant la glycolyse centrale dans le métabolisme. Des isoformes d'enzymes permettent une adaptation aux conditions d'oxygène variable.\n\nEn agronomie, la vigueur d'une culture dépend de l'équilibre entre production et utilisation des sucres. Des carences nutritives ou des stress limitent la glycolyse et se traduisent par une croissance ralentie."
+  },
+  {
+    "date": "2025-12-07",
+    "target": "Outil d’aide à la décision",
+    "text": "Les outils d'aide à la décision agrègent des données agronomiques, météorologiques et économiques pour proposer des recommandations. Ils peuvent être spécialisés par culture ou par thème.\n\nIls intègrent des modèles, des seuils d'alerte et des scénarios économiques. Les interfaces web ou mobiles facilitent leur utilisation sur le terrain.\n\nPour les exploitations, ces outils sécurisent les décisions, optimisent les intrants et améliorent la traçabilité. Leur performance dépend de la qualité des données saisies."
+  },
+  {
+    "date": "2025-12-08",
+    "target": "Culture de tissus",
+    "text": "La culture de tissus regroupe les techniques de culture in vitro de cellules, de tissus ou d'organes végétaux. Elle permet la régénération de plantes entières à partir de quelques cellules.\n\nLes conditions aseptiques, les milieux nutritifs et les régulateurs de croissance déterminent la réussite. Des callus se forment avant de se différencier en organes.\n\nCette technologie sert à la multiplication, à la conservation et à l'amélioration génétique. Elle ouvre la voie à la production de métabolites d'intérêt."
+  },
+  {
+    "date": "2025-12-09",
+    "target": "Couverts permanents",
+    "text": "Les couverts permanents restent en place plusieurs années, souvent dans les vergers ou vignobles, pour protéger le sol et favoriser la biodiversité. Ils demandent une gestion de la concurrence.\n\nDes espèces rustiques et tolérantes au piétinement sont choisies. Des tontes ou roulages réguliers maintiennent une hauteur compatible avec la culture principale.\n\nEn systèmes pérennes, les couverts permanents améliorent la portance, limitent l'érosion et servent d'habitat aux auxiliaires. Ils s'intègrent à la fertilisation organique."
+  },
+  {
+    "date": "2025-12-10",
+    "target": "Sclérenchyme",
+    "text": "Le sclérenchyme comprend des cellules mortes à parois lignifiées très épaisses, assurant un soutien rigide. On distingue les fibres et les sclérides.\n\nLes fibres s'allongent pour former des faisceaux tandis que les sclérides donnent des structures plus courtes et épaisses. Les ponctuations permettent un minimum de circulation.\n\nEn agriculture, la proportion de sclérenchyme influence la texture des fruits, la rigidité des tiges et la qualité des fibres textiles. Des variétés sont sélectionnées pour adapter cette teneur."
+  },
+  {
+    "date": "2025-12-11",
+    "target": "Tension de succion",
+    "text": "La tension de succion correspond à l'effort nécessaire pour extraire l'eau du sol, mesurée avec des tensiomètres. Elle indique la facilité d'accès à l'eau pour les racines.\n\nLes tensiomètres placés dans le sol enregistrent la dépression créée par l'assèchement. Les seuils d'alarme varient selon les cultures et la texture.\n\nEn pilotage de l'irrigation, surveiller la tension de succion permet de déclencher les apports au moment opportun et d'éviter les stress ou les excès d'eau."
+  },
+  {
+    "date": "2025-12-12",
+    "target": "Azote ammoniacal",
+    "text": "L'azote ammoniacal est une forme moins mobile que le nitrate, susceptible d'être adsorbée sur le complexe argilo-humique. Il peut être assimilé directement par les racines ou transformé par nitrification.\n\nSon assimilation passe par la glutamine synthétase et la glutamate synthase, enzymes clés du métabolisme azoté. Un excès d'ammonium dans la rhizosphère peut provoquer des déséquilibres ioniques et acidifier le milieu.\n\nEn pratique agricole, l'apport d'azote ammoniacal est privilégié sur sols froids ou pour des cultures capables de l'utiliser efficacement. Les inhibiteurs de nitrification prolongent sa présence et synchronisent mieux l'offre avec la demande des plantes."
+  },
+  {
+    "date": "2025-12-13",
+    "target": "Poil absorbant",
+    "text": "Les poils absorbants augmentent considérablement la surface d'échange des racines fines, captant eau et nutriments dissous. Leur durée de vie courte impose un renouvellement permanent en fonction des zones explorées.\n\nChaque poil est une extension d'une cellule du rhizoderme, dépourvue de cuticule, ce qui facilite les flux d'eau mais expose aux pathogènes du sol. Leur densité dépend des gradients hormonaux et de la disponibilité en phosphore.\n\nPour les cultures exigeantes, maintenir une humidité régulière et des apports organiques modérés favorise une forte densité de poils absorbants. Les pratiques de fertilisation localisée doivent rester douces pour ne pas les brûler."
+  },
+  {
+    "date": "2025-12-14",
+    "target": "Cryoconservation",
+    "text": "La cryoconservation préserve du matériel végétal à très basse température, souvent dans l'azote liquide, pour une conservation à long terme. Elle s'applique aux embryons, bourgeons ou graines.\n\nDes protocoles de prétraitement et de cryoprotection évitent la formation de cristaux de glace destructeurs. Le matériel est stocké dans des cryotanks sécurisés.\n\nPour les banques de ressources génétiques, la cryoconservation assure une sauvegarde durable et indépendante des aléas climatiques ou politiques. Elle complète les collections vivantes."
+  },
+  {
+    "date": "2025-12-15",
+    "target": "Analyse foliaire",
+    "text": "L'analyse foliaire mesure les concentrations en nutriments dans les feuilles pour diagnostiquer l'état nutritionnel des cultures. Elle complète les analyses de sol.\n\nDes prélèvements standardisés à des stades précis assurent des résultats comparables. Les interprétations s'appuient sur des références variétales.\n\nEn arboriculture, viticulture ou grandes cultures, l'analyse foliaire permet d'ajuster les apports en cours de cycle. Elle détecte les carences latentes avant l'apparition de symptômes."
+  },
+  {
+    "date": "2025-12-16",
+    "target": "Lutte intégrée",
+    "text": "La lutte intégrée combine des méthodes agronomiques, biologiques, physiques et chimiques pour contrôler les ravageurs avec un impact minimal sur l'environnement. Elle repose sur la prévention et la surveillance.\n\nLes stratégies incluent la rotation, les variétés résistantes, la lutte biologique, les seuils d'intervention et l'usage raisonné des pesticides. L'observation régulière est indispensable.\n\nEn agriculture durable, la lutte intégrée réduit les coûts et les risques, tout en maintenant la qualité des récoltes. Elle nécessite une formation continue et un réseau d'alerte efficace."
+  },
+  {
+    "date": "2025-12-17",
+    "target": "Bois final",
+    "text": "Le bois final est formé en fin de saison de végétation et se compose de cellules plus petites à parois épaisses, renforçant la structure de la tige. Il confère densité et résistance mécanique.\n\nLes vaisseaux y sont moins nombreux, laissant davantage de fibres sclérifiées. Cette partie du cerne est souvent plus sombre et plus résistante aux insectes xylophages.\n\nPour les producteurs de bois ou de fruits, un bois final bien formé garantit la solidité des charpentes et la résistance aux vents. Les pratiques de taille et de nutrition influencent son développement."
+  },
+  {
+    "date": "2025-12-18",
+    "target": "Cotylédon",
+    "text": "Les cotylédons sont les feuilles embryonnaires qui stockent ou transfèrent les réserves vers l'embryon. Ils peuvent émerger au-dessus du sol ou rester souterrains selon les espèces.\n\nIls abritent des tissus nutritifs et des enzymes qui soutiennent les premières étapes de la germination. Leur morphologie est un critère d'identification des familles botaniques.\n\nEn pépinière, protéger les cotylédons contre les ravageurs et les stress garantit une implantation réussie. Leur santé influence la vigueur initiale de la plantule."
+  },
+  {
+    "date": "2025-12-19",
+    "target": "Substrat laine de roche",
+    "text": "La laine de roche est un substrat minéral utilisé en culture hors sol, issu du basalte fondu et filé. Elle offre une grande porosité et une uniformité de production.\n\nLes plaques ou cubes sont irrigués par des solutions nutritives contrôlées. Le suivi de l'humidité et de l'EC dans le substrat est indispensable.\n\nEn horticulture sous serre, la laine de roche assure une croissance régulière et des rendements élevés. La gestion de la fin de cycle et du recyclage du substrat reste un enjeu environnemental."
+  },
+  {
+    "date": "2025-12-20",
+    "target": "Auxine",
+    "text": "L'auxine est une hormone végétale clé qui régule l'élongation cellulaire, la différenciation et la dominance apicale. Elle est synthétisée principalement dans les jeunes tissus.\n\nSon transport polarisé repose sur des transporteurs spécifiques comme PIN et AUX/LAX, créant des gradients fins. Ces flux orchestrent la formation des organes et la réponse aux stimuli.\n\nEn agriculture, les régulateurs de croissance à base d'auxine servent à favoriser l'enracinement des boutures, éclaircir les fruits ou contrôler l'émission des gourmands. Les doses doivent être précises pour éviter les phytotoxicités."
+  },
+  {
+    "date": "2025-12-21",
+    "target": "Lutte biologique",
+    "text": "La lutte biologique utilise des organismes vivants pour contrôler les ravageurs, qu'il s'agisse de prédateurs, parasitoïdes ou agents pathogènes. Elle s'intègre dans des stratégies durables.\n\nLa réussite dépend d'un diagnostic précis du ravageur, d'une sélection d'auxiliaires adaptés et d'un environnement favorable à leur installation. Des lâchers ou des conservations ciblées sont mis en place.\n\nEn agriculture, la lutte biologique réduit l'usage de pesticides et préserve les écosystèmes. Elle nécessite un suivi régulier et une formation technique des opérateurs."
+  },
+  {
+    "date": "2025-12-22",
+    "target": "Fibre libérienne",
+    "text": "Les fibres libériennes proviennent du phloème secondaire et constituent une matière première pour le textile. Elles sont longues, souples et résistantes.\n\nLeur maturation implique un renforcement de la paroi secondaire et une lignification partielle. Les procédés de rouissage et de teillage permettent de les isoler.\n\nPour les cultures de lin ou de chanvre, la qualité des fibres libériennes dépend de la densité de semis, de la nutrition et du moment de récolte. Un séchage maîtrisé préserve leurs propriétés."
+  },
+  {
+    "date": "2025-12-23",
+    "target": "Plastoglobule",
+    "text": "Les plastoglobules sont des structures lipidiques présentes dans les chloroplastes, stockant des pigments et des lipides neutres. Ils jouent un rôle dans le recyclage des membranes thylakoïdales.\n\nIls contiennent des enzymes impliquées dans la synthèse de caroténoïdes et de tocophérols, molécules protectrices contre l'oxydation. Leur taille augmente lors de la sénescence ou d'un stress lumineux.\n\nEn production, la qualité nutritionnelle des fruits et légumes dépend en partie de ces composés lipidiques. Des conditions de culture équilibrées limitent la dégradation prématurée des plastoglobules."
+  },
+  {
+    "date": "2025-12-24",
     "target": "Virus de la mosaïque du tabac",
     "text": "Le virus de la mosaïque du tabac (TMV) infecte de nombreuses solanacées, provoquant des marbrures, des nanismes et des déformations. Il est très stable et persistant dans l'environnement.\n\nLa transmission se fait par contact mécanique, outils ou mains contaminés. Il résiste aux désinfectants courants et peut rester infectieux dans les débris.\n\nLa prévention passe par l'hygiène stricte, l'utilisation de semences saines et des variétés résistantes. Une rotation longue et la désinfection des équipements sont indispensables."
   },
   {
-    "date": "2025-01-14",
-    "target": "Virus de la sharka",
-    "text": "Le virus de la sharka (PPV) affecte les fruits à noyau comme l'abricotier ou le pêcher, entraînant des marbrures, des déformations et une perte de qualité. Il se propage par pucerons et matériel végétal contaminé.\n\nLes symptômes se manifestent sur les feuilles, les fruits et les fleurs. La maladie entraîne des pertes économiques majeures dans les vergers.\n\nLa lutte repose sur l'arrachage des arbres infectés, la certification des plants et le contrôle des pucerons. Des programmes de sélection créent des variétés tolérantes."
+    "date": "2025-12-25",
+    "target": "Endosperme",
+    "text": "L'endosperme est un tissu triploïde formé par la double fécondation, accumulant des réserves pour l'embryon. Il peut persister dans la graine mature ou être entièrement consommé.\n\nSes cellules se chargent de glucides, protéines et lipides, souvent disposés en couches distinctes. Des signaux hormonaux régulent sa croissance et sa dégradation.\n\nPour les cultures céréalières, la qualité de l'endosperme détermine le rendement et les usages industriels. Des conditions de remplissage optimales assurent un grain bien structuré."
   },
   {
-    "date": "2025-01-15",
+    "date": "2025-12-26",
+    "target": "Salinité résiduelle",
+    "text": "La salinité résiduelle correspond aux sels accumulés dans le sol suite aux irrigations ou aux engrais, pouvant s'accroître au fil des saisons. Elle réduit la réserve utile en eau.\n\nDes analyses régulières du sol et de l'eau révèlent cette accumulation. Les sels se concentrent particulièrement en surface lors de l'évaporation.\n\nEn agriculture irriguée, gérer la salinité résiduelle nécessite des lessivages contrôlés, des rotations adaptées et une gestion fine des apports. Les systèmes de drainage contribuent à évacuer l'excès."
+  },
+  {
+    "date": "2025-12-27",
+    "target": "Ombrière",
+    "text": "L'ombrère filtre la lumière pour protéger les cultures sensibles aux brûlures ou aux excès de rayonnement. Elle abaisse aussi la température et réduit la transpiration.\n\nLes filets d'ombrage existent en différents taux de coupure et couleurs pour moduler le spectre lumineux. Leur installation doit permettre une adaptation saisonnière.\n\nEn pépinière, en horticulture ornementale ou sous serre, les ombrières améliorent la qualité des plants et réduisent les stress. Elles se combinent à l'irrigation fine et à la ventilation."
+  },
+  {
+    "date": "2025-12-28",
+    "target": "Culture intermédiaire",
+    "text": "La culture intermédiaire est implantée entre deux cultures principales pour couvrir le sol, capter les nitrates ou produire de la biomasse. Elle peut être restituée ou valorisée.\n\nLes espèces choisies s'adaptent au calendrier disponible et aux objectifs agronomiques : piège à nitrates, fourrage ou service structurel. Leur gestion détermine leur efficacité.\n\nEn agriculture durable, les cultures intermédiaires limitent les pertes d'azote, améliorent la structure et enrichissent la biodiversité. Elles nécessitent une planification précise de leur destruction."
+  },
+  {
+    "date": "2025-12-29",
+    "target": "Fertilisation potassique",
+    "text": "La fertilisation potassique soutient la régulation hydrique, la synthèse des sucres et la résistance aux stress. Le potassium active de nombreuses enzymes.\n\nIl est peu lessivable mais peut être retenu sur le complexe argilo-humique. Des apports en automne ou en pré-semis rechargent le sol.\n\nPour les cultures exigeantes comme la pomme de terre ou la betterave, une fertilisation potassique équilibrée assure qualité et rendement. Des analyses foliaires ajustent les doses en cours de cycle."
+  },
+  {
+    "date": "2025-12-30",
+    "target": "Photosynthèse C3",
+    "text": "La photosynthèse C3 est le mode majoritaire chez les plantes tempérées, fixant le CO₂ via la Rubisco dans le cycle de Calvin. Elle est sensible aux fortes températures et à la photorespiration.\n\nDans les cellules du mésophylle, les chloroplastes orchestrent la capture de lumière et la synthèse des trioses phosphates. La régénération du ribulose bisphosphate conditionne le débit de la chaîne.\n\nEn conduite culturale, optimiser la photosynthèse C3 passe par la gestion de la lumière, de l'azote et de l'eau pour limiter la photorespiration. Des variétés améliorées et des densités adaptées maximisent la biomasse produite."
+  },
+  {
+    "date": "2025-12-31",
+    "target": "Azote nitrique",
+    "text": "L'azote nitrique représente une forme très mobile dans le sol, facilement absorbée par les racines mais sujette au lessivage. Il résulte de la nitrification et alimente rapidement la synthèse des protéines végétales.\n\nAu niveau cellulaire, il est réduit en ammonium grâce à la nitrate réductase, une enzyme sensible à l'état nutritionnel et à la lumière. Son assimilation nécessite une énergie métabolique et un approvisionnement suffisant en carbone.\n\nEn fertilisation, ajuster les apports d'azote nitrique en fonction des stades critiques évite les pertes et les excès de vigueur. L'utilisation de couverts piégeant les nitrates limite les fuites hivernales et protège la qualité de l'eau."
+  },
+  {
+    "date": "2026-01-01",
+    "target": "Fertilisation azotée",
+    "text": "La fertilisation azotée apporte l'azote nécessaire à la croissance végétative et à la production de protéines. Elle doit être synchronisée avec les stades clés de la culture.\n\nLes formes ammoniacales, nitriques ou uréiques présentent des vitesses d'assimilation différentes. Des fractionnements et des outils de pilotage optimisent leur efficacité.\n\nPour les agriculteurs, une fertilisation azotée raisonnée tient compte des reliquats, des apports organiques et des objectifs de rendement. Elle limite les pertes par volatilisation et lessivage."
+  },
+  {
+    "date": "2026-01-02",
+    "target": "Semis sous couvert",
+    "text": "Le semis sous couvert implante la culture principale dans un couvert vivant ou récemment détruit. Il protège le sol et améliore l'infiltration de l'eau.\n\nLes semoirs spécialisés ouvrent un sillon étroit et déposent la graine sans bouleverser le couvert. La gestion de la biomasse est cruciale pour éviter la concurrence.\n\nEn agriculture de conservation, le semis sous couvert réduit l'érosion, favorise la vie du sol et stabilise la température. Il demande un pilotage précis des couverts et des apports azotés."
+  },
+  {
+    "date": "2026-01-03",
+    "target": "Micropropagation",
+    "text": "La micropropagation multiplie rapidement des plantes en laboratoire à partir de tissus méristématiques ou de fragments. Elle produit des plants sains et uniformes.\n\nLes explants sont cultivés sur des milieux gélifiés stériles contenant nutriments et hormones. Des phases de multiplication, d'enracinement et d'acclimatation se succèdent.\n\nEn horticulture et arboriculture, la micropropagation fournit des plants indemnes de virus, accélère la diffusion de nouvelles variétés et sécurise la production de porte-greffes."
+  },
+  {
+    "date": "2026-01-04",
+    "target": "Turgescence",
+    "text": "La turgescence maintient les tissus végétaux fermes grâce à la pression exercée par la vacuole sur la paroi cellulaire. Elle dépend de l'entrée d'eau dans la cellule via l'osmose.\n\nLes parois cellulosiques résistent à cette pression tout en permettant la croissance par relâchement contrôlé. Une turgescence suffisante est indispensable au maintien des feuilles et des tiges.\n\nEn horticulture, la turgescence conditionne l'aspect commercial des légumes-feuilles et des fleurs coupées. L'irrigation, la nutrition potassique et la fraîcheur après récolte sont des leviers pour la conserver."
+  },
+  {
+    "date": "2026-01-05",
+    "target": "Albumen",
+    "text": "L'albumen constitue la réserve nutritive de nombreuses graines, alimentant l'embryon lors de la germination. Il est riche en amidon, protéines et lipides selon les espèces.\n\nSa texture et sa composition évoluent durant la maturation, influençant la qualité des farines ou des semences. Des enzymes mobilisent ces réserves lors de la germination.\n\nEn agroalimentaire, la valeur de l'albumen conditionne l'usage des céréales et des légumineuses. Les pratiques de fertilisation et les conditions de remplissage déterminent sa qualité."
+  },
+  {
+    "date": "2026-01-06",
+    "target": "Modélisation phénologique",
+    "text": "La modélisation phénologique prédit les stades de développement des plantes en fonction des conditions climatiques. Elle s'appuie sur des cumuls de chaleur ou des modèles plus complexes.\n\nDes courbes de calibration par variété permettent d'ajuster les modèles. Les données météo locales sont essentielles pour la précision.\n\nEn agriculture, la modélisation phénologique aide à planifier les travaux, les traitements et les récoltes. Elle s'intègre dans des outils d'aide à la décision connectés."
+  },
+  {
+    "date": "2026-01-07",
+    "target": "Mulch vivant",
+    "text": "Le mulch vivant consiste à maintenir une culture de couverture basse entre les rangs pour protéger le sol et limiter les adventices. Il reste vivant pendant le cycle de la culture principale.\n\nCe couvert apporte de la matière organique par ses racines et ses résidus, tout en hébergeant des auxiliaires. Sa gestion nécessite un contrôle de la concurrence hydrique et nutritive.\n\nEn viticulture ou en maraîchage, le mulch vivant améliore l'infiltration de l'eau et la portance. Des espèces adaptées et des tontes régulières garantissent son efficacité."
+  },
+  {
+    "date": "2026-01-08",
+    "target": "Piège à phéromones",
+    "text": "Les pièges à phéromones attirent les insectes mâles grâce à des molécules mimant les émissions femelles. Ils permettent de suivre les populations et de déclencher les interventions.\n\nLeur design varie selon l'espèce ciblée, avec des pièges delta, entonnoir ou à eau. Les capsules de phéromones doivent être renouvelées régulièrement.\n\nEn protection intégrée, les pièges à phéromones servent d'outils de surveillance ou de lutte directe. Ils réduisent le recours aux insecticides en ciblant les périodes critiques."
+  },
+  {
+    "date": "2026-01-09",
+    "target": "Pectine",
+    "text": "Les pectines sont des polysaccharides riches en acide galacturonique, responsables de la cohésion des parois primaires et de la texture des fruits. Elles forment des gels en présence de calcium.\n\nLa dé-méthylation des pectines par les enzymes pectinestérases modifie leur capacité de gélification. Les pectines participent aussi aux réponses de défense en relarguant des oligogalacturonides.\n\nEn industrie, la teneur en pectine influence la fermeté des fruits et la qualité des confitures. Les pratiques de récolte et de stockage visent à préserver ces polysaccharides."
+  },
+  {
+    "date": "2026-01-10",
+    "target": "Structure grumeleuse",
+    "text": "La structure grumeleuse se compose d'agrégats arrondis et friables, riches en pores interconnectés qui favorisent l'infiltration et l'aération. Elle résulte d'une activité biologique intense.\n\nAu toucher, les agrégats se délitent facilement sans se compacter, signe d'une bonne cohésion organo-minérale. Les pores permettent une colonisation rapide par les racines fines.\n\nEn agronomie, maintenir une structure grumeleuse implique de limiter les passages d'engins par temps humide, d'apporter des matières organiques et de favoriser la vie du sol. Elle constitue la base d'un sol fertile et résilient."
+  },
+  {
+    "date": "2026-01-11",
+    "target": "Rouille jaune",
+    "text": "La rouille jaune du blé, causée par Puccinia striiformis, se manifeste par des pustules orangées alignées sur les feuilles. Elle se développe par temps frais et humide.\n\nLe champignon produit des spores très contagieuses transportées par le vent. Les attaques précoces entraînent une forte perte de rendement.\n\nDes variétés résistantes, des semis adaptés et un suivi des bulletins d'alerte permettent de contenir la rouille jaune. Des fongicides peuvent être nécessaires en cas de forte pression."
+  },
+  {
+    "date": "2026-01-12",
+    "target": "Irrigation par aspersion",
+    "text": "L'irrigation par aspersion distribue l'eau en gouttes fines projetées par des rampes, pivots ou canons. Elle imite une pluie artificielle.\n\nLe dimensionnement des buses, la pression et la vitesse d'avancement assurent une répartition homogène. Le vent et l'évaporation peuvent toutefois réduire l'efficacité.\n\nPour les agriculteurs, l'aspersion s'adapte à de nombreuses cultures et terrains. Son pilotage nécessite de surveiller les conditions météorologiques et la disponibilité en eau."
+  },
+  {
+    "date": "2026-01-13",
+    "target": "Salicylate",
+    "text": "L'acide salicylique est au cœur des défenses systémiques acquises, notamment contre les pathogènes biotrophes. Il déclenche la production de protéines PR et l'établissement d'une mémoire immunitaire.\n\nLes chloroplastes et le cytosol participent à sa synthèse via plusieurs voies métaboliques. Des vagues de signalisation électrique et hormonale diffusent l'information dans la plante.\n\nPour les agriculteurs, surveiller l'état des défenses salicylées aide à anticiper la sensibilité aux maladies. Certains produits de biocontrôle visent à activer cette voie sans recourir à des pesticides chimiques."
+  },
+  {
+    "date": "2026-01-14",
+    "target": "Conservation in situ",
+    "text": "La conservation in situ maintient les plantes dans leur environnement naturel ou dans les systèmes agricoles traditionnels. Elle conserve les interactions écologiques et les évolutions adaptatives.\n\nLes agriculteurs gardiens de semences jouent un rôle clé en cultivant des variétés locales année après année. Les politiques publiques soutiennent ces pratiques.\n\nCette conservation vivante assure une adaptation continue aux changements climatiques et aux pressions sanitaires. Elle complète les banques ex situ."
+  },
+  {
+    "date": "2026-01-15",
+    "target": "Méristème racinaire",
+    "text": "Le méristème racinaire assure la croissance continue des racines pour explorer de nouveaux volumes de sol. Sa coiffe protectrice amortit les chocs mécaniques et sécrète des mucilages qui facilitent la progression à travers les agrégats.\n\nLes cellules initiales s'organisent en colonnes donnant chacune un tissu : épiderme, cortex ou cylindre central. La présence d'un centre quiescent limite l'accumulation de mutations et sert de réserve pour régénérer le méristème après un stress.\n\nEn agronomie, soutenir l'activité du méristème racinaire passe par une bonne structure de sol, des apports organiques adaptés et la maîtrise de l'hydratation. Ces facteurs conditionnent l'exploration racinaire et donc l'absorption d'eau et de nutriments."
+  },
+  {
+    "date": "2026-01-16",
+    "target": "Porosité micro",
+    "text": "La porosité micro rassemble les pores fins situés à l'intérieur des agrégats, capables de retenir l'eau contre la gravité. Ils constituent une réserve hydrique essentielle pour les plantes.\n\nCette porosité résulte de l'empilement des particules d'argile et de la présence de matière organique colloïdale. Elle évolue selon l'humidité et le stade de dessiccation du sol.\n\nEn conduite culturale, optimiser la porosité micro passe par un équilibre entre structure et teneur en matière organique. Trop compacte, elle bloque les échanges gazeux ; trop lâche, elle ne retient plus l'eau pour la culture."
+  },
+  {
+    "date": "2026-01-17",
+    "target": "Oïdium du blé",
+    "text": "L’oïdium du blé est une maladie due à Blumeria graminis f.sp. tritici, formant un feutrage blanc sur les feuilles et les gaines. Il réduit la surface photosynthétique.\n\nLe champignon se propage par le vent et peut hiverner sur les résidus. Les symptômes apparaissent dès les stades jeunes par temps doux et humide.\n\nLa gestion passe par le choix variétal, la fertilisation équilibrée et des traitements ciblés lorsque le seuil est dépassé. Les pratiques culturales réduisant l'humidité foliaire limitent les attaques."
+  },
+  {
+    "date": "2026-01-18",
+    "target": "Paillage organique",
+    "text": "Le paillage organique recouvre le sol de matières végétales comme la paille, le foin ou le broyat. Il limite l'évaporation, réduit les adventices et nourrit la vie du sol en se décomposant.\n\nSa mise en place stabilise la température du sol et protège contre l'impact des pluies. Des apports réguliers maintiennent une couverture efficace tout au long du cycle.\n\nPour les agriculteurs et jardiniers, le paillage organique constitue un allié pour économiser l'eau et réduire les interventions mécaniques. Il favorise également la biodiversité fonctionnelle."
+  },
+  {
+    "date": "2026-01-19",
+    "target": "Sarclage",
+    "text": "Le sarclage enlève mécaniquement les adventices au voisinage immédiat des plantes, souvent à la main ou avec de petits outils. Il réduit la concurrence sans perturber fortement le sol.\n\nIl se pratique sur les lignes ou autour des plants, là où les outils de binage ne passent pas. Des sarclettes thermiques ou à lame oscillante complètent l'arsenal.\n\nEn maraîchage diversifié, un sarclage régulier maintient la propreté des planches et protège les cultures fragiles. Il demande une organisation rigoureuse pour intervenir au bon stade des adventices."
+  },
+  {
+    "date": "2026-01-20",
+    "target": "Rotation triennale",
+    "text": "La rotation triennale alterne trois cultures aux exigences différentes pour équilibrer les prélèvements et réduire les pressions parasitaires. Elle évite l'épuisement d'un élément nutritif.\n\nUn schéma classique associe une légumineuse, une céréale d'hiver et une culture de printemps. Chaque culture prépare le terrain pour la suivante.\n\nEn système agricole, une rotation triennale bien conçue améliore la fertilité, limite les adventices et lisse les risques économiques. Elle demande un suivi rigoureux des reliquats azotés."
+  },
+  {
+    "date": "2026-01-21",
+    "target": "Agriculture de conservation",
+    "text": "L'agriculture de conservation repose sur trois principes : couverture permanente du sol, travail minimal et rotations diversifiées. Elle vise à restaurer la fertilité et la biodiversité des sols.\n\nLes agriculteurs combinent des couverts végétaux, du semis direct et une gestion raisonnée des intrants. Des indicateurs biologiques et physiques suivent l'évolution du sol.\n\nCette approche réduit l'érosion, améliore la capacité d'infiltration et séquestre du carbone. Elle demande un changement global d'itinéraire technique et de matériel."
+  },
+  {
+    "date": "2026-01-22",
     "target": "Virose jaunisse nanisante",
     "text": "La jaunisse nanisante de l'orge est causée par un virus transmis par pucerons, provoquant un jaunissement et un nanisme. Elle réduit le tallage et le rendement.\n\nLe virus hiverne dans les plantes adventices ou les repousses. Les infestations précoces sont les plus dommageables.\n\nLes stratégies incluent la destruction des repousses, le choix de dates de semis moins exposées et, si nécessaire, des traitements insecticides ciblés. Des variétés tolérantes sont en développement."
   },
   {
-    "date": "2025-01-16",
+    "date": "2026-01-23",
+    "target": "Couverts gélifs",
+    "text": "Les couverts gélifs sont des espèces qui se détruisent naturellement avec le gel, facilitant le semis suivant sans intervention mécanique. Ils laissent une mulch protectrice.\n\nDes espèces comme la phacélie ou la moutarde sont utilisées pour leur croissance rapide et leur sensibilité au froid. Leur biomasse restitue des nutriments lors de la décomposition.\n\nPour les agriculteurs, les couverts gélifs simplifient l'itinéraire et limitent les coûts de destruction. Ils doivent être semés suffisamment tôt pour produire une biomasse efficace."
+  },
+  {
+    "date": "2026-01-24",
+    "target": "Ressource phytogénétique",
+    "text": "Les ressources phytogénétiques regroupent l'ensemble des variétés cultivées, des espèces sauvages apparentées et des collections conservées. Elles constituent la base de l'amélioration variétale.\n\nLeur gestion implique des inventaires, des banques de gènes et des programmes de valorisation. La propriété intellectuelle et l'accès aux ressources sont encadrés par des accords internationaux.\n\nPour la sécurité alimentaire, préserver les ressources phytogénétiques garantit la capacité à développer des variétés résilientes face aux nouvelles contraintes. Des réseaux internationaux coordonnent ces efforts."
+  },
+  {
+    "date": "2026-01-25",
+    "target": "Drainage de surface",
+    "text": "Le drainage de surface évacue les excès d'eau par des fossés ou des modelages du terrain, évitant la stagnation. Il complète le drainage souterrain lorsque la nappe est superficielle.\n\nDes pentes légères orientent l'écoulement vers des collecteurs, tandis que des rigoles temporaires gèrent les fortes pluies. La végétalisation des fossés limite l'érosion.\n\nPour les exploitations, un drainage de surface bien conçu protège les cultures des asphyxies et permet l'accès rapide aux parcelles après pluie. Un entretien régulier est indispensable."
+  },
+  {
+    "date": "2026-01-26",
+    "target": "Photosynthèse C4",
+    "text": "La photosynthèse C4 concentre le CO₂ avant son entrée dans le cycle de Calvin, réduisant la photorespiration et améliorant l'efficience en eau. Elle est caractéristique des graminées tropicales et de certaines adventices.\n\nLes cellules du mésophylle et de la gaine périvasculaire coopèrent via le cycle de Hatch-Slack, utilisant le malate et l'aspartate comme navettes. Cette partition anatomique confère une grande productivité en climat chaud.\n\nEn agriculture, les cultures C4 comme le maïs ou le sorgho valorisent mieux la lumière intense et l'eau limitée. Adapter la densité et les apports nutritifs permet d'exploiter ce potentiel élevé."
+  },
+  {
+    "date": "2026-01-27",
+    "target": "Acide abscissique",
+    "text": "L'acide abscissique (ABA) intervient dans la gestion du stress hydrique et la dormance des graines. Il s'accumule lors de la déshydratation et provoque la fermeture des stomates.\n\nLes récepteurs PYR/PYL déclenchent une cascade de signalisation qui active des facteurs de transcription spécifiques. L'ABA coordonne ainsi des réponses rapides et à long terme.\n\nEn agronomie, surveiller les niveaux d'ABA permet de comprendre la tolérance à la sécheresse et la maturation des fruits. Certaines pratiques culturale peuvent en moduler la synthèse ou la dégradation."
+  },
+  {
+    "date": "2026-01-28",
+    "target": "Tablette de multiplication",
+    "text": "La tablette de multiplication est un support chauffé et humidifié utilisé pour l'enracinement des boutures ou la germination. Elle crée un microclimat favorable et stable.\n\nDes câbles chauffants, des brumisateurs et des thermostats maintiennent des conditions optimales de température et d'humidité. Des capots transparents protègent des courants d'air.\n\nPour les pépiniéristes, une tablette de multiplication améliore le taux de reprise, accélère l'enracinement et uniformise la production. Elle facilite les séries successives de boutures."
+  },
+  {
+    "date": "2026-01-29",
+    "target": "Digestat",
+    "text": "Le digestat est le résidu issu de la méthanisation, contenant des nutriments minéralisés. Il se fractionne en phase liquide et solide.\n\nSa composition dépend des intrants du digesteur. Il nécessite un stockage étanche et une application raisonnée pour éviter les pertes par volatilisation ou lessivage.\n\nEn agriculture, le digestat remplace une partie des engrais minéraux et contribue au recyclage des effluents. Des plans d'épandage encadrent son utilisation."
+  },
+  {
+    "date": "2026-01-30",
+    "target": "Somme de températures",
+    "text": "La somme de températures cumule les degrés-jours au-dessus d'un seuil pour estimer la progression du cycle végétatif. Elle sert de base à de nombreux modèles phénologiques.\n\nChaque culture possède des seuils de base et des besoins en degrés-jours spécifiques. Les variations climatiques modulent l'accumulation.\n\nPour les producteurs, suivre la somme de températures aide à positionner les interventions, anticiper les risques de ravageurs et programmer les récoltes. Des stations météo locales fournissent ces données en continu."
+  },
+  {
+    "date": "2026-01-31",
+    "target": "Rotation légumineuse-céréale",
+    "text": "La rotation légumineuse-céréale exploite la capacité des légumineuses à fixer l'azote pour enrichir le sol avant une céréale. Elle optimise les apports d'azote minéral.\n\nLes résidus légumineux libèrent progressivement l'azote, réduisant les besoins de fertilisation de la culture suivante. Les maladies spécifiques sont également contenues.\n\nPour les agriculteurs, cette rotation améliore l'efficience azotée et la structure du sol. Elle s'accompagne d'une gestion fine des dates de semis et des destructions de couverts."
+  },
+  {
+    "date": "2026-02-01",
+    "target": "Ripisylve",
+    "text": "La ripisylve borde les cours d'eau et filtre les polluants issus des parcelles, stabilisant les berges. Elle abrite une biodiversité riche.\n\nLes racines maintiennent les sols, tandis que la litière ralentit les écoulements et favorise l'infiltration. Elle constitue un corridor écologique essentiel.\n\nPour les agriculteurs, préserver la ripisylve réduit les pertes de sol, améliore la qualité de l'eau et répond aux obligations réglementaires. Des programmes de restauration accompagnent son entretien."
+  },
+  {
+    "date": "2026-02-02",
+    "target": "Dénitrification",
+    "text": "La dénitrification réduit les nitrates en gaz nitreux ou en azote moléculaire dans les zones mal aérées du sol. Elle implique des bactéries hétérotrophes qui utilisent les nitrates comme accepteurs d'électrons en absence d'oxygène.\n\nCe processus dépend de la disponibilité en matière organique facilement dégradable et de la température. Il peut représenter une perte d'azote importante, mais contribue aussi à l'épuration des eaux excédentaires.\n\nDans les parcelles, limiter les périodes de saturation en eau et éviter les excès de fertilisation réduit les risques de dénitrification incontrôlée. Les drains, les bandes enherbées et les couverts végétaux jouent un rôle de tampon."
+  },
+  {
+    "date": "2026-02-03",
+    "target": "Tube pollinique",
+    "text": "Le tube pollinique se développe à partir du grain de pollen germé et progresse dans le style pour atteindre l'ovule. Il constitue la voie d'acheminement des gamètes mâles.\n\nSa croissance est guidée par des gradients chimiques et structuraux produits par les tissus femelles. Le cytosquelette et les vésicules sécrétoires soutiennent cette extension rapide.\n\nPour les producteurs, la connaissance des facteurs influençant la croissance du tube pollinique aide à optimiser les conditions de pollinisation. Une humidité et une nutrition adaptées du pistil sont essentielles."
+  },
+  {
+    "date": "2026-02-04",
+    "target": "Collenchyme",
+    "text": "Le collenchyme est un tissu de soutien constitué de cellules vivantes aux parois épaissies de manière inégale. Il accompagne les organes en croissance et leur confère flexibilité.\n\nLes épaississements pectocellulosiques s'accumulent surtout aux angles cellulaires, autorisant l'allongement. Les cellules restent riches en protoplasme et peuvent se différencier ultérieurement.\n\nEn maraîchage, la vigueur des tiges charnues dépend du collenchyme. Des déséquilibres nutritionnels ou des stress hydriques peuvent affaiblir ce tissu et provoquer des cassures."
+  },
+  {
+    "date": "2026-02-05",
+    "target": "Lenticelle",
+    "text": "Les lenticelles offrent une voie d'échange gazeux dans les organes ligneux recouverts de liège, assurant l'oxygénation des tissus internes. Elles se forment à partir du phellogène et remplacent les stomates perdus lors de la formation du périderme.\n\nLeur structure irrégulière, parfois en forme de lentille ou de fissure, présente des tissus lâches qui laissent diffuser l'air tout en empêchant les infiltrations excessives d'eau. Des subérifications partielles limitent les risques d'invasion pathogène.\n\nEn arboriculture fruitière, l'aspect des lenticelles renseigne sur la santé du bois et la qualité de la peau des fruits. Une humidité excessive peut les ouvrir et favoriser des infections, tandis qu'un stress hydrique prolongé tend à les refermer."
+  },
+  {
+    "date": "2026-02-06",
+    "target": "Double fécondation",
+    "text": "La double fécondation caractérise les angiospermes : un spermatozoïde fusionne avec l'oosphère pour former l'embryon, l'autre avec les noyaux polaires pour produire l'endosperme. Ce processus assure une synchronisation entre embryon et réserve nutritive.\n\nIl implique une coordination fine entre les cellules de l'ovule et les gamètes mâles. Des signaux moléculaires garantissent la reconnaissance et la fusion ciblée.\n\nEn amélioration variétale, maîtriser la double fécondation permet de produire des hybrides et de contrôler la formation des graines. Des pollinisations dirigées ou des manipulations d'ovules sont parfois nécessaires."
+  },
+  {
+    "date": "2026-02-07",
+    "target": "Culture en substrat coco",
+    "text": "La culture en substrat coco utilise des fibres de coco comme support inerte pour les plantes. Ce substrat possède une bonne rétention d'eau et une aération élevée.\n\nIl nécessite un arrosage fréquent avec une solution nutritive équilibrée et une gestion du drainage pour éviter l'accumulation de sels. La réutilisation impose une désinfection rigoureuse.\n\nPour les horticulteurs, la fibre de coco offre une alternative renouvelable à la tourbe. Elle s'adapte aux cultures hors sol comme la fraise ou la tomate."
+  },
+  {
+    "date": "2026-02-08",
+    "target": "Drainage souterrain",
+    "text": "Le drainage souterrain utilise des tuyaux enterrés pour évacuer l'eau excédentaire des horizons saturés. Il améliore l'aération et la portance des sols.\n\nLes drains posés à intervalles réguliers recueillent l'eau et la dirigent vers des exutoires. Leur profondeur et leur espacement dépendent du sol et de la culture.\n\nPour les agriculteurs, un drainage souterrain bien conçu prévient l'asphyxie racinaire, facilite les interventions mécaniques et limite la dénitrification. Il s'accompagne d'un suivi de la qualité des rejets."
+  },
+  {
+    "date": "2026-02-09",
+    "target": "Scarification",
+    "text": "La scarification consiste à altérer mécaniquement ou chimiquement le tégument des graines afin de lever la dormance tégumentaire. Elle augmente la perméabilité à l'eau.\n\nLes méthodes vont du frottement avec du papier abrasif au trempage dans des solutions acides contrôlées. Elles doivent être adaptées à l'épaisseur et à la fragilité du tégument.\n\nEn pépinière, la scarification est couramment utilisée pour les légumineuses ou les espèces ligneuses à graines dures. Un protocole précis évite les dommages à l'embryon tout en assurant une germination rapide."
+  },
+  {
+    "date": "2026-02-10",
+    "target": "Liège subéreux",
+    "text": "Le liège subéreux est un tissu mort produit par le phellogène, composé de cellules remplies d'air et de subérine. Il offre une protection thermique et hydrique à la plante.\n\nSes cellules polygonales empilées confèrent une grande compressibilité et une faible densité. Les couches successives s'accumulent et peuvent être récoltées chez certaines espèces.\n\nDans les cultures pérennes, un liège bien formé protège contre les agressions climatiques et les incendies. La récolte du liège nécessite une gestion fine pour ne pas endommager le phellogène."
+  },
+  {
+    "date": "2026-02-11",
+    "target": "Stromules",
+    "text": "Les stromules sont des tubules dynamiques émanant des chloroplastes, facilitant les échanges de métabolites et de signaux. Ils se déploient particulièrement en réponse aux stress ou aux besoins métaboliques accrus.\n\nLe cytosquelette d'actine guide leurs mouvements et favorise les contacts avec d'autres organites comme les mitochondries ou le noyau. Ils pourraient participer à la propagation de signaux de défense.\n\nDans les cultures, bien que non visibles à l'œil nu, les stromules témoignent d'une activité physiologique intense. La recherche agronomique s'y intéresse pour comprendre la coordination des réponses aux stress."
+  },
+  {
+    "date": "2026-02-12",
+    "target": "Stratification froide",
+    "text": "La stratification froide expose les graines à une période humide et fraîche pour lever certaines dormances physiologiques. Elle simule les conditions hivernales naturelles.\n\nDurant ce traitement, les inhibiteurs internes se dégradent et les tissus embryonnaires poursuivent leur maturation. La durée et la température doivent être contrôlées avec précision.\n\nEn pépinière forestière ou horticole, la stratification froide assure une germination homogène au printemps. Des substrats propres et une surveillance régulière évitent les contaminations fongiques."
+  },
+  {
+    "date": "2026-02-13",
+    "target": "Semoir pneumatique",
+    "text": "Le semoir pneumatique utilise l'air pour prélever, transporter et déposer les graines, offrant une grande polyvalence. Il s'adapte à des gammes variées de semences.\n\nDes disques perforés ou des chambres à dépression retiennent les graines avant de les relâcher au bon endroit. La pression d'air et le vide doivent être ajustés pour éviter les doublons ou les manques.\n\nEn grandes cultures, le semoir pneumatique permet des vitesses de chantier élevées tout en conservant une bonne précision. Un contrôle régulier des tuyaux et des flux d'air garantit une distribution uniforme."
+  },
+  {
+    "date": "2026-02-14",
+    "target": "Phototropisme",
+    "text": "Le phototropisme décrit l'orientation des organes en réponse à la lumière, favorisant la capture énergétique. Les tiges se courbent vers la source lumineuse grâce à une distribution asymétrique des auxines.\n\nLes photorécepteurs de type phototropines perçoivent les rayons bleus, déclenchant une cascade de signaux qui modifient la croissance cellulaire. Les cellules du côté ombré s'allongent davantage.\n\nEn conduite culturale, le phototropisme influence la densité de plantation et la gestion des éclairages artificiels. Des supports ou tuteurs sont parfois nécessaires pour canaliser ces courbures."
+  },
+  {
+    "date": "2026-02-15",
+    "target": "Semoir monograine",
+    "text": "Le semoir monograine dépose les semences une par une à intervalles réguliers, assurant une population homogène. Il est indispensable pour les cultures de précision comme le maïs ou la betterave.\n\nSon organe de distribution peut être mécanique, pneumatique ou à dépression. Les réglages doivent prendre en compte la taille des graines et la vitesse d'avancement.\n\nPour les agriculteurs, un semoir monograine bien calibré optimise la levée et facilite les opérations ultérieures. L'entretien des éléments semeurs et des contrôles électroniques est essentiel."
+  },
+  {
+    "date": "2026-02-16",
+    "target": "Stress hydrique",
+    "text": "Le stress hydrique survient lorsque la plante ne dispose pas d'eau suffisante pour maintenir sa turgescence et ses fonctions métaboliques. Il réduit la croissance et la production.\n\nLes symptômes vont du flétrissement à la réduction de la photosynthèse et au ralentissement du développement racinaire. Les hormones comme l'ABA se mobilisent.\n\nEn agronomie, anticiper le stress hydrique grâce à des outils de suivi et des stratégies d'irrigation permet de préserver le rendement. Des variétés tolérantes et des paillages limitent son impact."
+  },
+  {
+    "date": "2026-02-17",
     "target": "Maladie du dépérissement du chêne",
     "text": "Le dépérissement du chêne résulte d'un ensemble de facteurs biotiques et abiotiques, incluant champignons, insectes et stress climatiques. Il se traduit par un affaiblissement progressif des arbres.\n\nLes symptômes comprennent des feuilles brunies, des branches mortes et des attaques de scolytes. Les épisodes de sécheresse et les sols compactés aggravent la situation.\n\nLa gestion repose sur la surveillance, la diversification des essences, la réduction des stress et la recherche de facteurs favorisants. Des programmes de restauration visent à renforcer la résilience des peuplements."
+  },
+  {
+    "date": "2026-02-18",
+    "target": "Itinéraire technique",
+    "text": "L'itinéraire technique décrit l'ensemble des opérations réalisées sur une culture, de la préparation du sol à la récolte. Il intègre les choix variétaux, les apports et les interventions.\n\nChaque étape est planifiée selon des objectifs agronomiques, économiques et environnementaux. Des ajustements sont faits en fonction des observations au champ.\n\nPour les agriculteurs, formaliser l'itinéraire technique facilite l'analyse des performances, la communication avec les conseillers et la conformité réglementaire."
+  },
+  {
+    "date": "2026-02-19",
+    "target": "Horizon B du sol",
+    "text": "L'horizon B se caractérise par une accumulation de matériaux lessivés depuis la surface, comme les argiles, les oxydes de fer ou la matière organique. Sa couleur plus rouge ou plus dense témoigne de ces migrations.\n\nSa structure peut devenir plus massive ou prismatique, limitant parfois la circulation de l'eau et des racines. Les transitions entre horizon A et B dépendent du climat et de la nature du matériau parental.\n\nDans la gestion culturale, connaître la profondeur et la compacité de l'horizon B permet d'ajuster le travail du sol et le drainage. Des fissurations profondes ou des sous-soleuses ponctuelles peuvent améliorer son accessibilité."
+  },
+  {
+    "date": "2026-02-20",
+    "target": "Niveau d’infestation seuil",
+    "text": "Le niveau d’infestation seuil correspond à la densité de ravageurs à partir de laquelle une intervention est justifiée économiquement. Il prend en compte les dégâts potentiels et le coût des traitements.\n\nDes observations régulières au champ et des pièges permettent d'estimer la population. Les seuils varient selon la culture, le stade et le contexte économique.\n\nEn lutte intégrée, respecter les niveaux seuils évite des traitements inutiles et conserve les auxiliaires. Des outils d’aide à la décision intègrent ces valeurs."
+  },
+  {
+    "date": "2026-02-21",
+    "target": "Observation au champ",
+    "text": "L'observation au champ consiste à parcourir régulièrement les parcelles pour repérer les stades de développement, les adventices, les ravageurs et les maladies. C'est la base du pilotage agronomique.\n\nElle associe des observations visuelles, des notations et parfois des prélèvements pour analyses. Les outils numériques facilitent la consignation des données.\n\nPour les agriculteurs et conseillers, une observation rigoureuse permet des interventions ciblées, évite les traitements inutiles et améliore la compréhension du comportement des cultures."
+  },
+  {
+    "date": "2026-02-22",
+    "target": "Subérine",
+    "text": "La subérine est un polymère aliphatique et aromatique présent dans le liège et les barrières apoplastiques. Elle bloque les flux d'eau et renforce la protection contre les pathogènes.\n\nElle s'accumule dans les cellules endodermiques, notamment lors de la formation de la bande de Caspary. Sa composition varie selon les stress subis.\n\nEn agronomie, la subérisation des racines influe sur l'absorption hydrique et la tolérance aux sels. Des stress hydriques modérés peuvent stimuler sa formation pour protéger la plante."
+  },
+  {
+    "date": "2026-02-23",
+    "target": "Symplasme",
+    "text": "Le symplasme désigne l'ensemble des compartiments cellulaires reliés par les plasmodesmes, formant un réseau continu de transport. Les métabolites et hormones peuvent y circuler sans traverser les membranes plasmiques.\n\nCe réseau permet une coordination rapide des réponses physiologiques, notamment dans les tissus jeunes. Les barrières symplasmatiques peuvent se lever ou se renforcer selon les besoins.\n\nPour la conduite des cultures, favoriser une nutrition équilibrée soutient l'activité symplasmique et la distribution homogène des ressources. Des stress prolongés peuvent entraîner une fermeture de ces voies."
+  },
+  {
+    "date": "2026-02-24",
+    "target": "Cartographie de rendement",
+    "text": "La cartographie de rendement enregistre la production récoltée en chaque point du champ grâce à des capteurs sur les moissonneuses. Elle révèle l'hétérogénéité intra-parcellaire.\n\nLes données combinées à la géolocalisation permettent de repérer les zones à fort potentiel ou en difficulté. Des corrections de capteurs sont nécessaires pour fiabiliser les mesures.\n\nEn agronomie, analyser les cartes de rendement oriente les décisions de fertilisation variable, d'aménagement du sol et de sélection variétale. Elles servent de base au conseil de précision."
+  },
+  {
+    "date": "2026-02-25",
+    "target": "Rhizobium",
+    "text": "Les bactéries du genre Rhizobium initient la nodulation en pénétrant les racines des légumineuses via un filament d'infection. Elles adaptent leur métabolisme pour devenir des bactéroïdes capables de fixer l'azote.\n\nLeurs génomes portent des plasmides symbiotiques qui codent les facteurs Nod et les systèmes de fixation. La communication chimique avec la plante déclenche des courbures des poils absorbants et la formation du nodule.\n\nEn production, sélectionner des inoculums de Rhizobium compatibles avec la variété cultivée est crucial pour obtenir une fixation azotée optimale. Des analyses de nodulation en début de cycle permettent d'ajuster la stratégie de fertilisation."
+  },
+  {
+    "date": "2026-02-26",
+    "target": "Éthylène",
+    "text": "L'éthylène est un gaz régulateur de croissance qui contrôle la maturation des fruits, la sénescence et les réponses au stress. Sa diffusion rapide permet une communication locale entre tissus.\n\nIl est synthétisé à partir de la méthionine via la voie de l'ACC et agit par l'intermédiaire de récepteurs membranaires spécifiques. Les réponses incluent des modifications d'expression génique et de structure cellulaire.\n\nPour les producteurs, la gestion de l'éthylène est cruciale lors du stockage et du transport des fruits climactériques. Des absorbeurs, des inhibiteurs comme le 1-MCP ou des ventilations adaptées limitent ses effets indésirables."
+  },
+  {
+    "date": "2026-02-27",
+    "target": "Semis direct",
+    "text": "Le semis direct consiste à implanter les graines sans travail du sol profond, en conservant les résidus en surface. Il limite l'érosion et préserve la structure.\n\nLa gestion des couverts et des résidus est cruciale pour assurer un bon contact graine-sol et une levée rapide. Des semoirs spécifiques tranchent les résidus et déposent les graines à profondeur régulière.\n\nEn agriculture de conservation, le semis direct réduit les coûts de mécanisation et améliore la vie du sol. Il nécessite toutefois une maîtrise des adventices et de la fertilisation localisée."
+  },
+  {
+    "date": "2026-02-28",
+    "target": "Paroi primaire",
+    "text": "La paroi primaire entoure les cellules en croissance, composée de cellulose, hémicellulose et pectine. Elle reste flexible pour permettre l'expansion cellulaire.\n\nDes protéines structurales comme les extensines et les expansines modulent son relâchement. Les plasmodesmes la traversent pour assurer la communication.\n\nEn physiologie végétale, comprendre la paroi primaire aide à manipuler la croissance des fruits et des tiges. Les hormones et la nutrition modifient sa composition et son extensibilité."
+  },
+  {
+    "date": "2026-03-01",
+    "target": "Fertilisation phosphatée",
+    "text": "La fertilisation phosphatée fournit du phosphore, indispensable à la structure énergétique des cellules et à l'enracinement. Ce nutriment est peu mobile dans le sol.\n\nDes apports localisés ou des engrais starter favorisent son accès pour les jeunes plants. La solubilité dépend du pH et de la présence de calcium ou de fer.\n\nEn agronomie, gérer la fertilisation phosphatée implique d'analyser le sol, de choisir des formes adaptées et de favoriser la vie microbienne qui solubilise le phosphore. Les mycorhizes jouent un rôle clé."
+  },
+  {
+    "date": "2026-03-02",
+    "target": "Nitrification",
+    "text": "La nitrification convertit l'ammonium en nitrate grâce à deux groupes de bactéries autotrophes, Nitrosomonas et Nitrobacter. Ce processus a lieu dans les sols bien aérés et influence fortement la disponibilité en azote pour les plantes.\n\nAu niveau biochimique, il libère des protons qui acidifient localement la rhizosphère, modifiant l'équilibre des cations. La température, l'humidité et l'aération déterminent la vitesse de ces réactions successives.\n\nPour la gestion agronomique, ralentir la nitrification permet de synchroniser l'offre d'azote avec la demande de la culture et de limiter les pertes par lessivage. Des inhibiteurs spécifiques ou des apports fractionnés constituent des leviers efficaces."
+  },
+  {
+    "date": "2026-03-03",
+    "target": "Buttage",
+    "text": "Le buttage consiste à ramener de la terre au pied des plantes pour protéger les organes sensibles, favoriser l'émission de racines adventives ou limiter les adventices. Il améliore aussi le drainage autour du pied.\n\nCette opération se réalise avec des buttoirs ou des disques qui forment des billons plus ou moins hauts. Elle doit être effectuée au bon stade pour éviter d'étouffer les jeunes pousses.\n\nEn cultures de pomme de terre, de maïs ou de légumes, le buttage est un levier pour sécuriser le rendement et la qualité. Il s'intègre dans un itinéraire combinant binages et fertilisation localisée."
+  },
+  {
+    "date": "2026-03-04",
+    "target": "Capillarité",
+    "text": "La capillarité permet à l'eau de remonter dans les pores fins du sol et les tissus végétaux grâce à la tension de surface. Elle maintient un continuum hydrique entre les horizons en l'absence de saturation.\n\nLes parois cellulosiques et les micropores du sol offrent des surfaces d'adhésion qui soutiennent ces mouvements. Des gradients de diamètre conduisent à des vitesses de flux différentes et conditionnent l'alimentation en eau.\n\nPour les cultures, la capillarité est essentielle dans les substrats fins ou les zones irriguées par submersion. Maintenir une structure de sol stable garantit des pores fonctionnels et évite les ruptures de colonne."
+  },
+  {
+    "date": "2026-03-05",
+    "target": "Vermicompost",
+    "text": "Le vermicompost résulte de l'action de vers épigés qui transforment la matière organique en un amendement finement structuré. Il se produit à basse température.\n\nLes vers ingèrent les résidus pré-compostés et excrètent des turricules riches en nutriments et micro-organismes bénéfiques. Le processus nécessite une humidité et un pH contrôlés.\n\nEn maraîchage et horticulture, le vermicompost améliore la germination, la croissance et la résistance aux maladies. Il peut être utilisé en substrat ou en fertilisation liquide (thé de compost)."
+  },
+  {
+    "date": "2026-03-06",
+    "target": "Stress salin",
+    "text": "Le stress salin est provoqué par une concentration excessive de sels dans le sol ou l'eau, entraînant une réduction de l'absorption d'eau et des déséquilibres ioniques. Il affecte la croissance et la nutrition.\n\nLes plantes accumulent des ions toxiques comme le sodium et voient leur potentiel hydrique diminuer. Des mécanismes d'exclusion ou de compartimentation sont sollicités.\n\nPour les agriculteurs, gérer le stress salin implique de contrôler la qualité de l'eau d'irrigation, d'améliorer le drainage et de choisir des variétés tolérantes. Des amendements comme le gypse peuvent aider."
+  },
+  {
+    "date": "2026-03-07",
+    "target": "Racine fasciculée",
+    "text": "Les racines fasciculées forment un faisceau dense de racines de même diamètre qui explorent rapidement les premiers horizons du sol. Elles offrent une grande capacité d'absorption et stabilisent efficacement les particules superficielles.\n\nAu microscope, elles présentent de nombreux points d'émergence pour des racines secondaires, multipliant les zones d'échange et de colonisation mycorhizienne. Leur architecture confère une grande plasticité aux graminées.\n\nPour les céréales ou les oignons, la maîtrise du lit de semences et des irrigations d'implantation favorise un bon développement des racines fasciculées. Leur santé conditionne l'efficacité de l'absorption minérale et donc le rendement."
+  },
+  {
+    "date": "2026-03-08",
+    "target": "Phellogène",
+    "text": "Le phellogène est un méristème secondaire qui produit du liège vers l'extérieur et du phelloderme vers l'intérieur. Il remplace l'épiderme lorsque la tige s'épaissit.\n\nSes divisions périclines génèrent des tissus protecteurs imperméables et isolants. Son activité peut être cyclique selon les espèces et les saisons.\n\nEn arboriculture, préserver le phellogène est essentiel pour la cicatrisation des plaies et la qualité du liège chez le chêne-liège. Des blessures répétées peuvent perturber sa régénération."
+  },
+  {
+    "date": "2026-03-09",
+    "target": "Dormance tégumentaire",
+    "text": "La dormance tégumentaire provient d'une imperméabilité ou d'une résistance mécanique du tégument qui empêche l'entrée d'eau et d'oxygène. Elle retarde la germination jusqu'à la dégradation naturelle des barrières.\n\nDes cycles de gel-dégel, des passages dans le tube digestif ou l'action de micro-organismes lèvent progressivement cette dormance. Les couches lignifiées ou subérisées jouent un rôle clé.\n\nPour les techniciens de semences, diagnostiquer une dormance tégumentaire permet de choisir les traitements adéquats comme la scarification ou le trempage prolongé. Cela homogénéise l'émergence au champ."
+  },
+  {
+    "date": "2026-03-10",
+    "target": "Levée de dormance",
+    "text": "La levée de dormance regroupe l'ensemble des processus qui permettent à une graine dormante de redevenir apte à germer. Elle dépend de signaux environnementaux et internes.\n\nLes changements de température, d'humidité, de photopériode ou les traitements chimiques modifient les hormones comme l'ABA et les gibberellines. Les tissus tégumentaires se ramollissent progressivement.\n\nPour les producteurs de plants, maîtriser la levée de dormance garantit des calendriers de semis fiables. Des tests préalables permettent d'ajuster les protocoles selon les lots."
+  },
+  {
+    "date": "2026-03-11",
+    "target": "Horizon A du sol",
+    "text": "L'horizon A correspond à la couche de surface riche en matière organique et en activité biologique. C'est la zone principale d'enracinement des cultures et des échanges gazeux.\n\nSa structure grumeleuse et sa couleur sombre reflètent l'accumulation de résidus décomposés et de microfaune. Les agrégats y sont souvent plus stables grâce à l'activité des racines et des vers de terre.\n\nPour les agriculteurs, protéger l'horizon A revient à limiter l'érosion, éviter la compaction et maintenir une couverture végétale. Cette couche conditionne la fertilité et la capacité d'infiltration de la parcelle."
+  },
+  {
+    "date": "2026-03-12",
+    "target": "Binage",
+    "text": "Le binage aère la couche superficielle du sol et détruit les adventices en sectionnant leurs jeunes pousses. Il améliore l'infiltration de l'eau et casse la croûte de battance.\n\nLes outils vont des houes rotatives aux bineuses guidées par caméra, permettant un travail précis entre les rangs. Le binage favorise aussi la minéralisation de la matière organique.\n\nPour les producteurs en agriculture biologique ou de conservation, le binage reste un outil majeur de gestion des adventices. Il se combine avec des couverts et des rotations diversifiées."
+  },
+  {
+    "date": "2026-03-13",
+    "target": "Mildiou de la vigne",
+    "text": "Le mildiou de la vigne, causé par Plasmopara viticola, attaque les feuilles, grappes et rameaux sous climat humide. Il se manifeste par des taches huileuses et un feutrage blanc au revers des feuilles.\n\nLe cycle comprend des contaminations primaires à partir des oospores du sol puis des contaminations secondaires via les spores. Les périodes pluvieuses prolongées favorisent l'épidémie.\n\nLa lutte combine la surveillance, les prévisions météo, la gestion du feuillage et les traitements fongicides. Des cépages résistants complètent la stratégie."
+  },
+  {
+    "date": "2026-03-14",
+    "target": "Puceron vert du pêcher",
+    "text": "Le puceron vert du pêcher (Myzus persicae) est un ravageur polyphage qui colonise de nombreuses cultures et transmet des virus. Il forme des colonies sur les jeunes pousses.\n\nSa reproduction parthénogénétique permet des explosions de population rapides. Il se déplace entre plantes hôtes primaires et secondaires au fil des saisons.\n\nLa lutte repose sur la surveillance, l'installation de plantes pièges, la conservation des auxiliaires et, si nécessaire, des traitements raisonnées. Des variétés résistantes aux virus limitent les conséquences."
+  },
+  {
+    "date": "2026-03-15",
+    "target": "Embryon",
+    "text": "L'embryon est l'organisme miniature contenu dans la graine, déjà organisé avec une radicule, une tigelle et des cotylédons. Il résulte de la fusion des gamètes.\n\nDurant la maturation, il accumule des réserves et acquiert une tolérance à la dessiccation. Des gènes spécifiques contrôlent son dormance et sa future germination.\n\nEn multiplication végétale, protéger l'embryon contre les stress thermiques et mécaniques est primordial. Des tests de coupe ou de coloration évaluent sa viabilité."
+  },
+  {
+    "date": "2026-03-16",
+    "target": "Piétin-verse",
+    "text": "Le piétin-verse est une maladie fongique des céréales causée par Gaeumannomyces graminis, provoquant des lésions sur les racines et la base des tiges. Il entraîne des verse et des pertes de rendement.\n\nLe champignon survit dans les résidus et le sol, colonisant les racines au printemps. Les symptômes incluent un blanchiment des épis et des taches nécrotiques sur la gaine.\n\nLa gestion repose sur la rotation, l'utilisation de variétés tolérantes et des traitements de semences. Une fertilisation équilibrée limite la sensibilité."
+  },
+  {
+    "date": "2026-03-17",
+    "target": "Cycle de Calvin",
+    "text": "Le cycle de Calvin fixe le CO₂ pour produire des trioses phosphates, précurseurs des sucres et des réserves. Il dépend de l'activité de la Rubisco et de la régénération du ribulose bisphosphate.\n\nLes étapes de carboxylation, réduction et régénération se déroulent dans le stroma des chloroplastes, mobilisant ATP et NADPH issus des réactions lumineuses. Les régulations redox adaptent le cycle aux conditions de lumière.\n\nPour les agriculteurs, garantir une nutrition azotée et magnésienne adéquate soutient le cycle de Calvin et la productivité. Les stress qui réduisent l'activité enzymatique se traduisent rapidement par des baisses de rendement."
+  },
+  {
+    "date": "2026-03-18",
+    "target": "Photopériode contrôlée",
+    "text": "La photopériode contrôlée ajuste la durée du jour perçue par la plante pour déclencher la floraison ou le repos végétatif. Des écrans ou éclairages spécifiques modulent la lumière.\n\nLes plantes de jours courts ou de jours longs réagissent différemment à ces manipulations. Des cycles de lumière interrompue peuvent maintenir la croissance végétative.\n\nEn horticulture ornementale ou en production de plants, contrôler la photopériode synchronise la floraison et répond à la demande du marché. Cela nécessite des installations de fermeture ou d'éclairage programmables."
+  },
+  {
+    "date": "2026-03-19",
+    "target": "Tégument",
+    "text": "Le tégument entoure la graine et la protège contre les agressions physiques et biologiques. Il est issu des enveloppes de l'ovule et peut être imperméable.\n\nSa structure comprend souvent une couche externe cutinisée, une couche sclérifiée et des pigments. Il abrite parfois des composés inhibiteurs de la germination.\n\nEn agriculture, la qualité du tégument influence la conservation des semences et la levée de dormance. Des traitements appropriés assurent une germination homogène au semis."
+  },
+  {
+    "date": "2026-03-20",
+    "target": "Rouille brune",
+    "text": "La rouille brune du blé, due à Puccinia triticina, provoque des pustules brun-orangé dispersées sur le feuillage. Elle apparaît plutôt en fin de cycle par temps chaud.\n\nLes spores germent sur les feuilles humides et infectent rapidement les tissus. Des cycles successifs augmentent la pression en conditions favorables.\n\nLa lutte repose sur le choix variétal, la rotation et la surveillance. Des traitements curatifs peuvent être déclenchés au-delà des seuils recommandés."
+  },
+  {
+    "date": "2026-03-21",
+    "target": "Photolyse de l'eau",
+    "text": "La photolyse de l'eau se produit dans le photosystème II, scindant l'eau en électrons, protons et oxygène sous l'effet de la lumière. Ce processus fournit les électrons nécessaires à la chaîne de transport.\n\nLe complexe d'évolution de l'oxygène contient des ions manganèse qui orchestrent les différentes étapes d'oxydation. Les protons libérés contribuent à la formation du gradient chimiosmotique.\n\nPour les cultures, assurer une bonne nutrition en manganèse et en lumière favorise une photolyse efficace. Des déficiences se traduisent par une baisse de photosynthèse et des chloroses."
+  },
+  {
+    "date": "2026-03-22",
+    "target": "Phloème",
+    "text": "Le phloème distribue les assimilats produits par la photosynthèse vers les organes demandeurs, qu'il s'agisse de jeunes feuilles, de racines ou de réserves. Sa plasticité permet de réorienter les flux selon les besoins, par exemple vers une inflorescence en croissance rapide ou un tubercule en remplissage.\n\nSur une coupe colorée, les tubes criblés et leurs cellules compagnes révèlent un contenu visqueux riche en sucres et en hormones de signalisation. Les plaques criblées se renouvellent régulièrement et les calloses formées en réponse au stress servent de vannes pour isoler une portion du réseau.\n\nPour l'agronome, tout facteur qui freine la photosynthèse ou endommage le phloème se traduit immédiatement par une perte de rendement. Les stratégies de lutte contre les insectes piqueurs-suceurs, la gestion du stress hydrique et le choix variétal influencent donc directement l'efficacité de cette voie de transport."
+  },
+  {
+    "date": "2026-03-23",
+    "target": "Hémicellulose",
+    "text": "Les hémicelluloses sont des polysaccharides ramifiés qui relient la cellulose à la matrice pectique. Elles contribuent à l'élasticité de la paroi.\n\nLeur composition varie selon les espèces, incluant des xylanes, mannane ou glucanes. Elles interagissent avec la lignine dans les parois secondaires.\n\nPour les technologies de transformation des fibres, l'extraction des hémicelluloses conditionne la qualité du papier ou des biomatériaux. En nutrition animale, elles participent à l'apport en fibres digestibles."
+  },
+  {
+    "date": "2026-03-24",
+    "target": "Indice foliaire (LAI)",
+    "text": "L'indice foliaire mesure la surface de feuilles par unité de surface de sol, évaluant la densité du couvert végétal. Il sert à estimer la capture de lumière et l'évapotranspiration.\n\nDes capteurs optiques ou des méthodes destructives permettent de le mesurer. Les modèles de croissance utilisent le LAI pour ajuster leurs prédictions.\n\nEn agriculture, suivre le LAI aide à optimiser les densités de semis, les apports azotés et les interventions phytosanitaires. Il renseigne sur l'état de santé du couvert."
+  },
+  {
+    "date": "2026-03-25",
+    "target": "Bilan hydrique",
+    "text": "Le bilan hydrique compare les apports d'eau (pluie, irrigation) aux pertes (évapotranspiration, drainage) pour déterminer les besoins de la culture. Il se calcule sur des périodes variables.\n\nDes modèles intègrent la météo, le stade de la plante, la réserve utile du sol et les caractéristiques variétales. Ils fournissent des recommandations d'irrigation.\n\nPour les exploitations, suivre le bilan hydrique aide à planifier les apports, sécuriser les rendements et économiser l'eau. Des outils numériques facilitent ces calculs."
+  },
+  {
+    "date": "2026-03-26",
+    "target": "Tonoplaste",
+    "text": "Le tonoplaste est la membrane qui entoure la vacuole et contrôle les échanges entre cytoplasme et compartiment vacuolaire. Il porte des pompes à protons, des antiporteurs et des canaux ioniques.\n\nSon activité maintient des gradients de pH et d'ions nécessaires au stockage des métabolites et à la détoxification. Des protéines aquaporines y régulent aussi les flux d'eau.\n\nPour les cultures, la performance du tonoplaste influe sur la tolérance aux stress salins ou métalliques. Des apports équilibrés en nutriments et la sélection variétale contribuent à sa robustesse."
+  },
+  {
+    "date": "2026-03-27",
+    "target": "Filet anti-insectes",
+    "text": "Les filets anti-insectes protègent les cultures en créant une barrière physique contre les ravageurs volants. Ils réduisent aussi l'impact du vent et de la grêle selon leur maille.\n\nLe choix de la densité de maille s'adapte au ravageur ciblé, tandis que l'installation doit garantir une bonne ventilation pour éviter les excès d'humidité. Des structures solides supportent le filet.\n\nPour les maraîchers, les filets anti-insectes sécurisent des cultures sensibles comme les brassicacées ou les cucurbitacées. Ils s'intègrent à une stratégie globale de protection."
+  },
+  {
+    "date": "2026-03-28",
+    "target": "Cicadelle de la flavescence",
+    "text": "La cicadelle Scaphoideus titanus transmet la flavescence dorée de la vigne, une maladie à phytoplasme. Elle se nourrit sur les feuilles et injecte l'agent pathogène.\n\nLes larves se développent sur les bois de vigne et nécessitent des températures estivales pour compléter leur cycle. Les symptômes apparaissent l'année suivante avec un jaunissement et un flétrissement des grappes.\n\nLa lutte combine la surveillance, l'arrachage des ceps contaminés, des insecticides ciblés et la gestion des repousses. Des filets anti-insectes et des cépages tolérants sont à l'étude."
+  },
+  {
+    "date": "2026-03-29",
+    "target": "Culture verticale",
+    "text": "La culture verticale superpose plusieurs niveaux de production, souvent en environnement contrôlé. Elle maximise la productivité au mètre carré.\n\nL'éclairage LED, la gestion climatique et les systèmes hydroponiques ou aéroponiques sont intégrés dans des tours ou étagères. Les flux d'air et de nutriments sont finement pilotés.\n\nPour les producteurs urbains, la culture verticale offre une production de proximité, une traçabilité élevée et une faible consommation d'eau. Elle nécessite un investissement initial important et une maintenance continue."
+  },
+  {
+    "date": "2026-03-30",
+    "target": "Jasmonate",
+    "text": "Les jasmonates sont des hormones impliquées dans les réponses de défense et la régulation de la croissance. Elles se synthétisent rapidement après une attaque d'herbivore ou un stress mécanique.\n\nLeur signalisation implique le complexe COI1-JAZ qui libère des facteurs de transcription spécifiques. Les métabolites dérivés diffusent dans la plante pour coordonner la réponse.\n\nEn agriculture, stimuler ou préserver la signalisation jasmonate peut renforcer la résistance naturelle des cultures. Des bio-intrants et des pratiques de stress léger sont parfois utilisés pour amorcer ces réponses."
+  },
+  {
+    "date": "2026-03-31",
+    "target": "Chaux magnésienne",
+    "text": "La chaux magnésienne corrige l'acidité du sol tout en apportant du magnésium, élément central de la chlorophylle. Elle améliore la disponibilité des nutriments.\n\nSon épandage se planifie hors période de végétation active pour laisser le temps à la réaction de s'opérer. Le choix de granulométrie influence la vitesse d'action.\n\nPour les exploitations, l'utilisation de chaux magnésienne s'inscrit dans une stratégie d'amendement calco-magnésien, complétant la fertilisation et équilibrant le rapport Ca/Mg."
+  },
+  {
+    "date": "2026-04-01",
+    "target": "Virus de la sharka",
+    "text": "Le virus de la sharka (PPV) affecte les fruits à noyau comme l'abricotier ou le pêcher, entraînant des marbrures, des déformations et une perte de qualité. Il se propage par pucerons et matériel végétal contaminé.\n\nLes symptômes se manifestent sur les feuilles, les fruits et les fleurs. La maladie entraîne des pertes économiques majeures dans les vergers.\n\nLa lutte repose sur l'arrachage des arbres infectés, la certification des plants et le contrôle des pucerons. Des programmes de sélection créent des variétés tolérantes."
+  },
+  {
+    "date": "2026-04-02",
+    "target": "Station météo connectée",
+    "text": "La station météo connectée collecte en continu des données locales de température, humidité, vent, pluie et rayonnement. Elle transmet ces informations vers des plateformes en ligne.\n\nDes capteurs spécifiques peuvent suivre la tension de surface foliaire, l'humectation ou la température du sol. Les données alimentent des modèles de maladies ou d'irrigation.\n\nPour les agriculteurs, une station connectée fournit des alertes personnalisées, améliore la planification des travaux et documente les pratiques pour la traçabilité."
+  },
+  {
+    "date": "2026-04-03",
+    "target": "Prairie permanente",
+    "text": "La prairie permanente reste en herbe pendant plusieurs années, offrant une couverture continue et des racines profondes. Elle séquestre du carbone et nourrit les troupeaux.\n\nSa flore diversifiée améliore la structure du sol, la biodiversité et la résilience face aux aléas climatiques. Les rotations de pâturage optimisent son potentiel.\n\nPour les éleveurs, la prairie permanente constitue une ressource fourragère stable et un support de services environnementaux. Une gestion raisonnée du pâturage et des apports organiques en assure la pérennité."
+  },
+  {
+    "date": "2026-04-04",
+    "target": "Apoplasme",
+    "text": "L'apoplasme correspond aux espaces extracellulaires et aux parois cellulaires, offrant une voie de transport sans franchir la membrane plasmique. Il joue un rôle dans la circulation de l'eau et des ions jusqu'à l'endoderme.\n\nDes dépôts de subérine au niveau de la bande de Caspary interrompent cette voie, obligeant un passage par le symplasme. Les interactions avec les composés de la paroi influencent la disponibilité des nutriments.\n\nEn agronomie, le fonctionnement de l'apoplasme conditionne l'efficacité des engrais foliaires et la distribution de certains pesticides systémiques. Des recherches visent à optimiser ces voies pour réduire les doses appliquées."
+  },
+  {
+    "date": "2026-04-05",
+    "target": "Vacuole centrale",
+    "text": "La vacuole centrale occupe la majeure partie du volume cellulaire, stockant l'eau, les solutés et de nombreux métabolites. Elle contribue à la turgescence et au maintien de la forme cellulaire.\n\nSes membranes, le tonoplaste, contiennent des transporteurs spécialisés régulant le pH et la composition ionique. Des compartiments vacuolaires peuvent se spécialiser pour accumuler des pigments ou des composés de défense.\n\nEn horticulture, la gestion de l'irrigation et de la nutrition influe sur le remplissage vacuolaire et la fermeté des tissus récoltés. Des stress hydriques peuvent réduire la turgescence et provoquer des flétrissements."
+  },
+  {
+    "date": "2026-04-06",
+    "target": "Complexe argilo-humique",
+    "text": "Le complexe argilo-humique résulte de l'association entre particules d'argile et matière organique, formant des agrégats stables riches en charges négatives. Il joue un rôle central dans la fertilité chimique en retenant les cations nutritifs.\n\nCette structure colloïdale protège les argiles de la dispersion et sert de support à la vie microbienne. Elle influence la floculation et la stabilité des agrégats face aux pluies battantes.\n\nLes pratiques qui préservent le complexe argilo-humique incluent l'apport d'amendements organiques, la limitation du travail intensif et la couverture permanente du sol. Elles maintiennent une fertilité durable et limitent les lessivages."
+  },
+  {
+    "date": "2026-04-07",
+    "target": "Cuticule foliaire",
+    "text": "La cuticule foliaire protège les tissus internes contre la déshydratation et les agressions extérieures grâce à sa composition en cutine et cires. Elle reflète une partie du rayonnement solaire et limite l'adhésion des gouttelettes, réduisant la durée d'humectation des feuilles.\n\nObservée en microscopie électronique, elle montre des strates successives et des micro-reliefs qui influencent la mouillabilité et la diffusion de composés volatils. Son épaisseur et sa composition évoluent selon l'âge de la feuille et les conditions climatiques.\n\nPour les agriculteurs, la cuticule conditionne l'efficacité des traitements foliaires et la résistance aux sécheresses ponctuelles. Adapter le volume d'eau, le pH des bouillies et choisir des adjuvants appropriés aide à traverser cette barrière sans l'endommager."
+  },
+  {
+    "date": "2026-04-08",
+    "target": "Stomate",
+    "text": "Les stomates régulent les échanges de gaz entre la plante et l'atmosphère, ajustant l'ouverture des ostioles en fonction de la lumière, de l'humidité et de la disponibilité en CO₂. Leur réactivité permet d'équilibrer photosynthèse et transpiration.\n\nLes cellules de garde renferment des chloroplastes actifs et une paroi interne épaissie qui orchestre l'ouverture en modifiant la turgescence. Des cellules annexes et le réseau d'ions potassium, malate ou chlorures assurent les variations osmotiques rapides.\n\nEn conduite culturale, maîtriser l'irrigation, la nutrition potassique et le climat autour de la culture soutient le fonctionnement stomatique. Des stress répétés peuvent entraîner des dysfonctionnements et diminuer la capacité photosynthétique."
+  },
+  {
+    "date": "2026-04-09",
+    "target": "Serre bioclimatique",
+    "text": "La serre bioclimatique optimise les échanges d'énergie pour réduire les besoins en chauffage ou refroidissement. Elle s'appuie sur l'inertie thermique, la ventilation naturelle et l'orientation.\n\nDes parois isolées, des murs à forte capacité thermique et des écrans mobiles régulent la température. La gestion de l'humidité et du CO₂ complète l'approche.\n\nPour les producteurs, une serre bioclimatique diminue les charges énergétiques et améliore la résilience face aux aléas climatiques. Elle nécessite une conception soignée et un pilotage précis."
+  },
+  {
+    "date": "2026-04-10",
+    "target": "Indice de verdure NDVI",
+    "text": "Le NDVI est un indice spectral basé sur la réflexion du rouge et du proche infrarouge, indiquant la vigueur et la biomasse du végétal. Il varie de -1 à 1.\n\nLes satellites, drones ou capteurs embarqués fournissent des cartes de NDVI à différentes échelles. Les variations temporelles détectent les stress précoces.\n\nPour les exploitations, le NDVI permet de zoner les parcelles, d'ajuster les doses d'engrais et d'identifier les zones à risque. Il s'intègre dans les outils d'agriculture de précision."
+  },
+  {
+    "date": "2026-04-11",
+    "target": "Matière organique stable",
+    "text": "La matière organique stable constitue la fraction humifiée persistante du sol, agissant comme réserve de nutriments et régulateur de structure. Elle se forme lentement à partir des résidus végétaux et animaux transformés par la vie du sol.\n\nSes composés aromatiques et colloïdaux possèdent une forte capacité d'échange cationique, améliorant la rétention d'éléments fertilisants. Ils contribuent également à la couleur sombre et à la capacité tampon du sol.\n\nEn agriculture durable, maintenir ou accroître la matière organique stable passe par l'apport régulier de résidus, de composts mûrs et la réduction du travail intensif. Elle favorise la résilience face à la sécheresse et à l'érosion."
+  },
+  {
+    "date": "2026-04-12",
+    "target": "Fertirrigation",
+    "text": "La fertirrigation combine fertilisation et irrigation en injectant des nutriments dans le réseau d'arrosage. Elle synchronise l'apport avec les besoins de la plante.\n\nDes solutions nutritives sont préparées selon les stades de croissance et contrôlées par des capteurs de conductivité. La qualité de l'eau et l'acidification éventuelle sont surveillées.\n\nPour les cultures sous serre, fruitières ou de plein champ irriguées, la fertirrigation optimise les rendements et réduit les pertes. Elle nécessite un matériel précis et des analyses régulières."
+  },
+  {
+    "date": "2026-04-13",
+    "target": "Banque de semences",
+    "text": "Les banques de semences conservent des échantillons de ressources génétiques pour préserver la diversité végétale. Elles stockent les graines dans des conditions contrôlées de température et d'humidité.\n\nDes protocoles de régénération et de duplication garantissent la viabilité à long terme. Les accès sont documentés avec des passeports génétiques et des informations agronomiques.\n\nPour l'agriculture, les banques de semences fournissent des ressources pour la sélection, la recherche et la restauration des variétés locales. Elles constituent un patrimoine commun."
+  },
+  {
+    "date": "2026-04-14",
+    "target": "Horizon C du sol",
+    "text": "L'horizon C correspond au matériau parental faiblement altéré, souvent constitué de fragments rocheux ou de dépôts meubles. Il marque la transition vers la roche mère.\n\nLes processus biologiques y sont plus limités, mais des racines profondes peuvent exploiter ses fissures pour accéder à l'eau. La nature de cet horizon conditionne la vitesse de régénération des horizons supérieurs.\n\nPour les cultures pérennes, la connaissance de l'horizon C guide le choix des porte-greffes et des techniques de plantation. Des analyses géotechniques peuvent révéler des contraintes chimiques ou physiques à anticiper."
+  },
+  {
+    "date": "2026-04-15",
+    "target": "Nématode à kystes",
+    "text": "Les nématodes à kystes (Globodera spp., Heterodera spp.) parasitent les racines de cultures comme la pomme de terre ou la betterave. Ils forment des kystes remplis d'œufs qui survivent plusieurs années.\n\nLes infestations entraînent un nanisme, une chlorose et une réduction du rendement. Les kystes se disséminent via le sol et le matériel agricole.\n\nLa gestion s'appuie sur des rotations longues, des variétés résistantes, des plantes pièges et l'hygiène du matériel. Des analyses de sol détectent leur présence."
+  },
+  {
+    "date": "2026-04-16",
+    "target": "Métabolisme CAM",
+    "text": "Le métabolisme CAM stocke le CO₂ la nuit sous forme d'acides organiques pour le libérer le jour, permettant de fermer les stomates en période chaude. Il est typique des plantes succulentes des milieux arides.\n\nLes vacuoles accumulent le malate nocturne, tandis que les chloroplastes le décarboxylent le jour pour alimenter le cycle de Calvin. Les rythmes circadiens pilotent cette alternance.\n\nPour les producteurs de plantes ornementales ou aromatiques CAM, la gestion de l'arrosage et de la luminosité doit respecter ces rythmes. Des excès d'humidité peuvent perturber la fermeture nocturne des stomates."
+  },
+  {
+    "date": "2026-04-17",
+    "target": "Plasmodesme",
+    "text": "Les plasmodesmes relient les cellules végétales en traversant les parois, permettant le passage de signaux et de molécules. Ils créent un continuum cytoplasmique entre cellules adjacentes.\n\nUne membrane dérivée du réticulum endoplasmique, le desmotubule, occupe leur centre, tandis que l'ouverture latérale se régule par des dépôts de callose. La plante ajuste leur perméabilité selon les besoins.\n\nEn agronomie, la compréhension des plasmodesmes est cruciale pour lutter contre les virus qui les utilisent comme route de propagation. Des variétés résistantes ou des traitements ciblés cherchent à limiter ces déplacements."
+  },
+  {
+    "date": "2026-04-18",
+    "target": "Plasmolyse",
+    "text": "La plasmolyse survient lorsque la cellule perd de l'eau et que la membrane plasmique se détache de la paroi, conséquence d'un milieu externe hypertonique. Ce phénomène est souvent réversible si l'eau revient.\n\nAu microscope, on observe des poches d'eau se former et la membrane se rétracter autour du protoplaste. Les plasmodesmes se ferment temporairement pour protéger la cellule.\n\nEn post-récolte, éviter des solutions trop concentrées lors de traitements chimiques limite les plasmolyses irréversibles. Une gestion douce de la dessiccation préserve la qualité des produits."
+  },
+  {
+    "date": "2026-04-19",
+    "target": "Cellulose",
+    "text": "La cellulose constitue le squelette des parois végétales, formant des microfibrilles résistantes et insolubles. Elle confère une grande solidité tout en permettant une certaine flexibilité.\n\nLes microfibrilles s'assemblent en faisceaux orientés, modulant la direction de la croissance cellulaire. Les complexes de cellulose synthase à la membrane plasmique orchestrent sa polymérisation.\n\nEn industrie agroalimentaire, la teneur en cellulose influence la texture des fibres et la digestibilité des fourrages. Des itinéraires techniques adaptés permettent de gérer son accumulation."
+  },
+  {
+    "date": "2026-04-20",
+    "target": "Aleurode",
+    "text": "Les aleurodes, ou mouches blanches, sucent la sève des cultures sous serre ou de plein champ, transmettent des virus et sécrètent du miellat. Elles prolifèrent par temps chaud et sec.\n\nLeur cycle rapide et la présence de nombreux biotypes compliquent la lutte. Les larves se fixent sur la face inférieure des feuilles, protégées par une cuticule cireuse.\n\nLes stratégies incluent la lutte biologique avec des parasitoïdes, les filets anti-insectes, les panneaux chromatiques et des traitements ciblés. La rotation des modes d'action évite les résistances."
+  },
+  {
+    "date": "2026-04-21",
+    "target": "Parenchyme spongieux",
+    "text": "Le parenchyme spongieux forme un réseau lacunaire facilitant les échanges gazeux entre les cellules chlorophylliennes et les stomates. Ses espaces intercellulaires servent de réserve temporaire de CO₂ et de voie de diffusion de la vapeur d'eau.\n\nLes cellules y sont plus arrondies et disposées de façon lâche, ce qui favorise la circulation de l'air mais impose une cohésion par des faisceaux conducteurs bien ancrés. Les gradients de concentration qui s'y établissent conditionnent la vitesse de la photosynthèse.\n\nPour les cultures sous serre ou en champ, la gestion de l'humidité ambiante et de la ventilation limite les risques de condensation dans ce tissu. Une atmosphère trop saturée favorise les pathogènes foliaires et ralentit les échanges gazeux indispensables à la croissance."
+  },
+  {
+    "date": "2026-04-22",
+    "target": "Porosité macro",
+    "text": "La porosité macro correspond aux pores de grande taille qui assurent le drainage rapide de l'eau et la circulation de l'air. Ils se situent entre les agrégats ou dans les fissures du sol.\n\nCes vides se forment grâce à l'activité biologique, aux cycles de dessiccation et aux actions mécaniques comme le gel-dégel. Leur proportion influence la vitesse d'infiltration et la capacité d'aération.\n\nPour les agriculteurs, préserver la porosité macro suppose d'éviter le tassement et d'entretenir une couverture végétale aux racines vigoureuses. Un sol bien drainé limite les maladies racinaires et facilite le ressuyage."
+  },
+  {
+    "date": "2026-04-23",
+    "target": "Aéroponie",
+    "text": "L'aéroponie cultive les plantes sans substrat, en pulvérisant périodiquement une solution nutritive sur les racines suspendues. Elle maximise l'oxygénation racinaire.\n\nLes buses de brumisation, la conductivité et la désinfection de l'eau sont des paramètres critiques. Les racines sont protégées de la lumière pour éviter l'oxydation.\n\nEn production de plants et de semences, l'aéroponie accélère la croissance, améliore la qualité sanitaire et réduit l'utilisation de substrats. Elle demande une alimentation électrique sécurisée."
   }
 ]

--- a/index.html
+++ b/index.html
@@ -55,7 +55,6 @@
   .token{display:inline}
   .pillScore{display:inline-block;margin-left:8px;padding:2px 8px;border-radius:999px;border:1px solid #e5e7eb;background:#fff;font-size:12px}
   .exp{margin-top:10px;padding:12px;border:1px dashed #e5e7eb;border-radius:12px;background:#fafafa}
-  .ped-actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
 </style>
 </head>
 <body>
@@ -188,27 +187,20 @@
       <div class="rowL" style="justify-content:space-between">
         <h2 style="margin:0">Pédantix du jour <span id="pedScore" class="pillScore" hidden></span></h2>
         <div class="rowL">
+          <button id="pedInfo" class="btn outline" type="button" aria-expanded="false" aria-controls="pedInfoPanel" title="Afficher les règles">ℹ️ Info</button>
           <button id="pedReset" class="btn outline">Réinitialiser du jour</button>
         </div>
       </div>
       <p class="muted" id="pedTitleMask"></p>
-      <div class="exp ped-desc">
-        <p><strong>Découvrez la page Wikipédia&nbsp;!</strong></p>
-        <p>Le but du jeu est de découvrir la page Wikipédia en révélant les mots qui composent son introduction par essais successifs.</p>
-        <p>Les mots corrects apparaîtront en clair au fur et à mesure que vous les essaierez. Ceux qui sont suffisamment proches resteront grisés avec un niveau de gris proportionnel à la proximité du mot réel dans le champ lexical. Ce calcul de proximité est similaire à celui utilisé par Cémantix. Vous pouvez voir la longueur d’un mot caché en pressant sur sa boîte noire.</p>
-        <p>Lorsque les mots composant le titre de la page Wikipédia seront dévoilés, vous aurez gagné&nbsp;! Notez que les mots du titre sont corrects ou pas, ils ne sont jamais grisés. La forme masculine singulière d’un mot ou l’infinitif d’un verbe peuvent suffire à révéler ses formes féminines, plurielles ou conjuguées. Les majuscules ne sont pas nécessaires.</p>
-        <p>À la fin de la partie, vous aurez le choix entre afficher la page, révéler chaque mot séparément en cliquant sur sa boîte noire, ou continuer à jouer sans spoiler.</p>
+      <div id="pedInfoPanel" class="exp ped-desc" hidden>
+        <p><strong>Objectif :</strong> taper des mots pour dévoiler progressivement l’introduction et deviner le titre caché.</p>
+        <p>Les mots trouvés deviennent lisibles, les autres restent masqués. Clique ou maintiens sur une boîte noire pour connaître la longueur d’un mot.</p>
       </div>
       <div id="pedText" class="pedantix-text"></div>
       <div class="row" style="justify-content:flex-start;margin-top:12px">
         <input id="pedInput" class="choice" placeholder="Tape un mot (objectif : le titre caché)" />
       </div>
       <ol id="pedGuesses" class="results"></ol>
-      <div id="pedWinActions" class="ped-actions" hidden>
-        <a id="pedShowPage" class="btn outline" target="_blank" rel="noopener">Afficher la page Wikipédia</a>
-        <button id="pedRevealToggle" class="btn outline" type="button" aria-pressed="false">Révéler mot par mot</button>
-        <button id="pedContinue" class="btn outline" type="button">Continuer sans spoiler</button>
-      </div>
     </div>
   </section>
 </main>
@@ -751,7 +743,19 @@ $("profReset").onclick=()=>{ resetProfFields(); profOutput.value=""; };
 
 /* ========= PÉDANTIX (daily) — lemmatisation FR renforcée ========= */
 const wordRe = /[A-Za-zÀ-ÖØ-öø-ÿ'-]+|[^A-Za-zÀ-ÖØ-öø-ÿ'-]+/g;
-let pedState = { date:null, target:null, text:"", tokens:[], revealed:new Set(), guessed:[], targetKeys:new Set() };
+let pedState = {
+  date: null,
+  target: null,
+  text: "",
+  tokens: [],
+  titleTokens: [],
+  revealed: new Set(),
+  fullTargetKeys: new Set(),
+  titleLetters: 0,
+  won: false,
+};
+const pedInfoBtn = $("pedInfo");
+const pedInfoPanel = $("pedInfoPanel");
 
 /* irréguliers + participes présents fréquents (sans accents car strip) */
 const IRREG_FORMS = {
@@ -993,7 +997,34 @@ function tokenize(text){
     return { raw:p, norm, lemma, isWord, keys };
   });
 }
+function tokenizeTitle(title){
+  const parts = (title || "").match(wordRe) || [];
+  return parts.map(part=>{
+    const isWord = /[A-Za-zÀ-ÖØ-öø-ÿ'-]+/.test(part);
+    if(!isWord){
+      return { raw: part, isWord: false };
+    }
+    const norm = strip(part);
+    const lemma = lemmaFr(part);
+    const keys = buildKeySet(norm, lemma, part);
+    const chars = [...part];
+    const letters = chars.filter(ch=>/[A-Za-zÀ-ÖØ-öø-ÿ]/.test(ch)).length || part.length;
+    const mask = chars.map(ch=>/[A-Za-zÀ-ÖØ-öø-ÿ]/.test(ch) ? "█" : ch).join("");
+    return { raw: part, isWord: true, keys, revealed: false, letters, mask };
+  });
+}
 function titleMask(){
+  if(pedState.titleTokens && pedState.titleTokens.length){
+    const total = pedState.titleLetters || pedState.titleTokens.reduce((acc, token)=>{
+      return acc + (token.isWord ? (token.letters || 0) : 0);
+    }, 0);
+    const display = pedState.titleTokens.map(token=>{
+      if(!token.isWord) return token.raw;
+      return (pedState.won || token.revealed) ? token.raw : token.mask;
+    }).join("");
+    const label = total === 1 ? "lettre" : "lettres";
+    return `Titre : ${display} (${total} ${label})`;
+  }
   if(!pedState.target) return "";
   const letters = [...pedState.target];
   const masked = letters.map(ch=>{
@@ -1001,7 +1032,9 @@ function titleMask(){
     if(/[A-Za-zÀ-ÖØ-öø-ÿ]/.test(ch)) return "█";
     return ch;
   }).join("");
-  return `Titre : ${masked} (${letters.filter(c=>/[A-Za-zÀ-ÖØ-öø-ÿ]/.test(c)).length} lettres)`;
+  const total = letters.filter(c=>/[A-Za-zÀ-ÖØ-öø-ÿ]/.test(c)).length;
+  const label = total === 1 ? "lettre" : "lettres";
+  return `Titre : ${masked} (${total} ${label})`;
 }
 function renderPed(){
   $("pedTitleMask").textContent = titleMask();
@@ -1016,14 +1049,7 @@ function renderPed(){
     mask.dataset.letters = String(letterCount);
     mask.tabIndex = 0;
     const baseLabel = `Mot caché de ${letterCount} lettre${letterCount>1?'s':''}`;
-    const updateLabel = ()=>{
-      let extra = "";
-      if(pedState.allowManualReveal){
-        extra = pedState.manualReveal ? " — cliquer pour dévoiler" : " — maintenir pour voir la longueur";
-      }
-      mask.setAttribute("aria-label", baseLabel + extra);
-    };
-    updateLabel();
+    mask.setAttribute("aria-label", baseLabel);
     const showLen = ()=>{
       mask.textContent = `${letterCount} lettre${letterCount>1?'s':''}`;
       mask.classList.add("mask-show");
@@ -1031,11 +1057,6 @@ function renderPed(){
     const hideLen = ()=>{
       mask.textContent = mask.dataset.mask || masked;
       mask.classList.remove("mask-show");
-    };
-    const revealToken = ()=>{
-      if(!pedState.allowManualReveal || !pedState.manualReveal) return;
-      token.keys.forEach(k=>pedState.revealed.add(k));
-      renderPed();
     };
     mask.addEventListener("mousedown", evt=>{ evt.preventDefault(); showLen(); });
     mask.addEventListener("mouseup", hideLen);
@@ -1050,19 +1071,8 @@ function renderPed(){
         showLen();
       }
     });
-    mask.addEventListener("keyup", evt=>{
-      hideLen();
-      if((evt.key===" " || evt.key==="Enter") && pedState.allowManualReveal && pedState.manualReveal){
-        evt.preventDefault();
-        revealToken();
-      }
-    });
-    mask.addEventListener("click", evt=>{
-      if(pedState.allowManualReveal && pedState.manualReveal){
-        evt.preventDefault();
-        revealToken();
-      }
-    });
+    mask.addEventListener("keyup", hideLen);
+    mask.addEventListener("click", evt=>{ evt.preventDefault(); showLen(); setTimeout(hideLen, 200); });
     return mask;
   };
   pedState.tokens.forEach(t=>{
@@ -1070,8 +1080,12 @@ function renderPed(){
     span.className = "token";
     if(!t.isWord){ span.textContent = t.raw; }
     else {
-      const show = hasIntersection(t.keys, pedState.revealed) || hasIntersection(t.keys, pedState.targetKeys);
-      span.innerHTML = show ? t.raw : `<span class="mask">${"█".repeat(Math.max(1, t.raw.length))}</span>`;
+      const show = pedState.won || hasIntersection(t.keys, pedState.revealed);
+      if(show){
+        span.textContent = t.raw;
+      } else {
+        span.appendChild(makeMask(t));
+      }
     }
     frag.appendChild(span);
   });
@@ -1083,11 +1097,15 @@ function pickDaily(){
   pedState.target = (entry && entry.target) || "Chloroplaste";
   pedState.text = (entry && entry.text) || "Texte démo.";
   pedState.tokens = tokenize(pedState.text);
+  pedState.titleTokens = tokenizeTitle(pedState.target);
+  pedState.titleLetters = pedState.titleTokens.reduce((acc, token)=>{
+    return acc + (token.isWord ? (token.letters || 0) : 0);
+  }, 0);
   pedState.revealed = new Set(); // tout masqué
-  pedState.targetKeys = buildKeySet(strip(pedState.target), lemmaFr(pedState.target), pedState.target);
-  pedState.guessed = [];
-  resetPedWinUI();
-  if(pedShowPage){ pedShowPage.href = wikiUrl(pedState.target); }
+  pedState.fullTargetKeys = buildKeySet(strip(pedState.target), lemmaFr(pedState.target), pedState.target);
+  pedState.won = false;
+  if(pedInfoPanel){ pedInfoPanel.hidden = true; }
+  if(pedInfoBtn){ pedInfoBtn.setAttribute("aria-expanded","false"); }
   $("pedGuesses").innerHTML=""; $("pedScore").hidden=true;
   renderPed();
 }
@@ -1096,33 +1114,37 @@ function guessWord(w){
   const gNorm = strip(gRaw);
   const gLemma = lemmaFr(gRaw);
   const guessKeys = buildKeySet(gNorm, gLemma, gRaw);
-  const win = hasIntersection(guessKeys, pedState.targetKeys);
+  const wasWon = pedState.won;
   let hits = 0;
-  if(!win){
-    for(const t of pedState.tokens){
-      if(!t.isWord) continue;
-      if(hasIntersection(t.keys, guessKeys)){
-        hits++;
-        t.keys.forEach(k=>pedState.revealed.add(k));
-      }
+  for(const t of pedState.tokens){
+    if(!t.isWord) continue;
+    if(hasIntersection(t.keys, guessKeys)){
+      const alreadyVisible = hasIntersection(t.keys, pedState.revealed);
+      if(!alreadyVisible) hits++;
+      t.keys.forEach(k=>pedState.revealed.add(k));
     }
-  } else {
+  }
+
+  for(const token of pedState.titleTokens){
+    if(!token.isWord || token.revealed) continue;
+    if(hasIntersection(token.keys, guessKeys)){
+      token.revealed = true;
+    }
+  }
+
+  const fullMatch = hasIntersection(guessKeys, pedState.fullTargetKeys);
+  if(fullMatch){
+    pedState.won = true;
+  } else if(!pedState.won && pedState.titleTokens.every(token=>!token.isWord || token.revealed)){
+    pedState.won = true;
+  }
+
+  if(pedState.won){
+    pedState.titleTokens.forEach(token=>{ if(token.isWord) token.revealed = true; });
     pedState.tokens.forEach(t=>{ if(t.isWord) t.keys.forEach(k=>pedState.revealed.add(k)); });
   }
   renderPed();
-  return {hits,win};
-}
-function pedHint(){
-  const cand=[];
-  for(const t of pedState.tokens){
-    if(!t.isWord) continue;
-    if(hasIntersection(t.keys, pedState.targetKeys)) continue;
-    if(!hasIntersection(t.keys, pedState.revealed)) cand.push(t);
-  }
-  if(!cand.length) return;
-  const t = cand[Math.floor(Math.random()*cand.length)];
-  t.keys.forEach(k=>pedState.revealed.add(k));
-  renderPed();
+  return {hits,win:(!wasWon && pedState.won)};
 }
 $("pedInput").addEventListener("keydown",e=>{
   if(e.key!=="Enter") return;
@@ -1131,24 +1153,18 @@ $("pedInput").addEventListener("keydown",e=>{
   const li=document.createElement("li"); li.className="result-item";
   li.innerHTML=`<div class="num ${win?'ok':(hits>0?'ok':'ko')}">${$("pedGuesses").children.length+1}</div><div><b>${val}</b> — ${win?'🎯 Titre trouvé !':(hits>0?`${hits} occurrence(s)`:'0')}</div>`;
   $("pedGuesses").prepend(li);
-  if(win){ $("pedScore").hidden=false; $("pedScore").textContent="BRAVO !"; }
+  if(win){
+    $("pedScore").hidden=false;
+    $("pedScore").textContent="BRAVO !";
+  }
   $("pedInput").value="";
 });
 $("pedReset").onclick=pickDaily;
-if(pedRevealToggle){
-  pedRevealToggle.addEventListener("click",()=>{
-    if(!pedState.allowManualReveal) return;
-    pedState.manualReveal = !pedState.manualReveal;
-    updateRevealToggle();
-    renderPed();
-  });
-}
-if(pedContinueBtn){
-  pedContinueBtn.addEventListener("click",()=>{
-    pedState.manualReveal=false;
-    updateRevealToggle();
-    if(pedWinActions) pedWinActions.hidden=true;
-    renderPed();
+if(pedInfoBtn && pedInfoPanel){
+  pedInfoBtn.addEventListener("click",()=>{
+    const expanded = pedInfoBtn.getAttribute("aria-expanded") === "true";
+    pedInfoBtn.setAttribute("aria-expanded", expanded ? "false" : "true");
+    pedInfoPanel.hidden = expanded;
   });
 }
 


### PR DESCRIPTION
## Summary
- split Pedantix titles into word tokens so individual guesses uncover each piece
- keep the masked title display in sync with revealed words and count remaining letters accurately
- finish the game when all title words are uncovered or the full title is guessed, revealing the full intro text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38d669648832e816709d61973b520